### PR TITLE
Added Identity Matrix Generator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ add_test(run_factorizations_tests factorizations_tests)
 add_executable(generators_tests
   src/lin_generators_randoms.cpp
   test/generators/constants_test.cpp
+  test/generators/identity_test.cpp
   test/generators/randoms_test.cpp
 )
 target_include_directories(generators_tests PRIVATE

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 
 # lin
 
-[![Build Status](https://travis-ci.com/kkrol27/lin.svg?branch=master)](https://travis-ci.com/kkrol27/lin)
-
 Linear algebra library solely using static memory alocation. It's been developed primarily for the [PAN](https://github.com/pathfinder-for-autonomous-navigation) mission.
 
 The library is structured into a set of individual modules.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 
 # lin
 
+[![Build Status](https://travis-ci.com/kkrol27/lin.svg?branch=master)](https://travis-ci.com/kkrol27/lin)
+
 Linear algebra library solely using static memory alocation. It's been developed primarily for the [PAN](https://github.com/pathfinder-for-autonomous-navigation) mission.
 
 The library is structured into a set of individual modules.

--- a/include/lin/generators.hpp
+++ b/include/lin/generators.hpp
@@ -6,6 +6,7 @@
 #define LIN_GENERATORS_HPP_
 
 #include "generators/constants.hpp"
+#include "generators/identity.hpp"
 #include "generators/randoms.hpp"
 
 #endif

--- a/include/lin/generators/identity.hpp
+++ b/include/lin/generators/identity.hpp
@@ -1,0 +1,33 @@
+/** @file lin/generators/identity.hpp
+ *  @author Kyle Krol
+ *  Defines a generator to create identity matrices. */
+
+#ifndef LIN_GENERATORS_IDENTITY_HPP_
+#define LIN_GENERATORS_IDENTITY_HPP_
+
+#include "../core.hpp"
+
+#include <type_traits>
+
+namespace lin {
+namespace internal {
+
+/** @class StreamIdentity */
+template <typename T, size_t N, size_t MN>
+class StreamIdentity;
+
+}  // namespace internal
+
+/** @fn identity */
+template <typename T, size_t N, size_t MN = N>
+constexpr internal::StreamIdentity<T, N, MN> identity(size_t n = MN);
+
+/** @fn identity */
+template <class C, std::enable_if_t<internal::is_square<C>::value, size_t> = 0>
+constexpr auto identity(size_t n = C::Traits::MaxRows);
+
+}  // namespace lin
+
+#include "inl/identity.inl"
+
+#endif

--- a/include/lin/generators/inl/constants.inl
+++ b/include/lin/generators/inl/constants.inl
@@ -47,12 +47,11 @@ class StreamConstants : public Stream<StreamConstants<T, R, C, MR, MC>>,
 template <typename T, size_t R, size_t C, size_t MR, size_t MC>
 struct _traits<StreamConstants<T, R, C, MR, MC>> {
   typedef T Elem;
-  enum : size_t {
-    Rows = R,
-    Cols = C,
-    MaxRows = MR,
-    MaxCols = MC
-  };
+  constexpr static size_t
+      Rows = R,
+      Cols = C,
+      MaxRows = MR,
+      MaxCols = MC;
 };
 
 template <typename T, size_t R, size_t C, size_t MR, size_t MC>

--- a/include/lin/generators/inl/identity.inl
+++ b/include/lin/generators/inl/identity.inl
@@ -1,0 +1,83 @@
+/** @file lin/generators/inl/identity.inl
+ *  @author Kyle Krol
+ *  See % lin/generators/identity.hpp for more information. */
+
+#include "../identity.hpp"
+
+namespace lin {
+namespace internal {
+
+template <typename T, size_t N, size_t MN>
+class StreamIdentity : public Stream<StreamIdentity<T, N, MN>>,
+    public Dimensions<StreamIdentity<T, N, MN>> {
+ public:
+  /* Import elements from Stream<StreamIdentity<T, N, MN>>. */
+  using Stream<StreamIdentity<T, N, MN>>::size;
+  using Stream<StreamIdentity<T, N, MN>>::eval;
+  /* Import elements from Dimensions<StreamIdentity<T, N, MN>> */
+  using Dimensions<StreamIdentity<T, N, MN>>::rows;
+  using Dimensions<StreamIdentity<T, N, MN>>::cols;
+  /* Include traits information. */
+  typedef traits<StreamIdentity<T, N, MN>> Traits;
+  /* Defaulted/deleted constructors and assignment operators. */
+  constexpr StreamIdentity() = default;
+  constexpr StreamIdentity(StreamIdentity<T, N, MN> const &) = default;
+  constexpr StreamIdentity(StreamIdentity<T, N, MN> &&) = default;
+  constexpr StreamIdentity<T, N, MN> &operator=(StreamIdentity<T, N, MN> const &) = default;
+  constexpr StreamIdentity<T, N, MN> &operator=(StreamIdentity<T, N, MN> &&) = default;
+  /* StreamConstants constructor(s). */
+  constexpr StreamIdentity(size_t n);
+  /* Element access/evaluation functions. */
+  constexpr typename Traits::Elem operator()(size_t i, size_t j) const;
+  constexpr typename Traits::Elem operator()(size_t i) const;
+
+ protected:
+  /* Import elements from Stream<StreamConstants<T, R, C, MR, MC>>. */
+  using Stream<StreamIdentity<T, N, MN>>::derived;
+
+ private:
+  /* Import elements from Dimensions<StreamConstants<T, R, C, MR, MC>>. */
+  using Dimensions<StreamIdentity<T, N, MN>>::resize;
+};
+
+template <typename T, size_t N, size_t MN>
+struct _traits<StreamIdentity<T, N, MN>> {
+  typedef T Elem;
+  constexpr static size_t
+      Rows = N,
+      Cols = N,
+      MaxRows = MN,
+      MaxCols = MN;
+};
+
+template <typename T, size_t N, size_t MN>
+constexpr StreamIdentity<T, N, MN>::StreamIdentity(size_t n) {
+  resize(n, n);
+}
+
+template <typename T, size_t N, size_t MN>
+constexpr typename StreamIdentity<T, N, MN>::Traits::Elem
+StreamIdentity<T, N, MN>::operator()(size_t i, size_t j) const {
+  LIN_ASSERT(0 <= i && i <= rows() /* Invalid argument passed to StreamIdentity<...>::operator() */);
+  LIN_ASSERT(0 <= j && j <= cols() /* Invalid argument passed to StreamIdentity<...>::operator() */);
+  return (i == j ? T(1) : T(0));
+}
+
+template <typename T, size_t N, size_t MN>
+constexpr typename StreamIdentity<T, N, MN>::Traits::Elem
+StreamIdentity<T, N, MN>::operator()(size_t i) const {
+  return (*this)(i / cols(), i % cols());
+}
+}  // namespace internal
+
+template <typename T, size_t N, size_t MN>
+constexpr internal::StreamIdentity<T, N, MN> identity(size_t n) {
+  return internal::StreamIdentity<T, N, MN>(n);
+}
+
+/** @fn identity */
+template <class C, std::enable_if_t<internal::is_square<C>::value, size_t>>
+constexpr auto identity(size_t n) {
+  return internal::StreamIdentity<typename C::Traits::Elem, C::Traits::Rows, C::Traits::MaxRows>(n);
+}
+}  // namespace lin

--- a/test/generators/identity_test.cpp
+++ b/test/generators/identity_test.cpp
@@ -1,0 +1,24 @@
+/** @file test/generators/identity_test.cpp
+ *  @author Kyle Krol */
+
+#include <lin/core.hpp>
+#include <lin/generators/identity.hpp>
+
+#include <gtest/gtest.h>
+
+TEST(GeneratorsIdentity, Identity) {
+  lin::Matrix3x3f A {
+    1.0f, 0.0f, 0.0f,
+    0.0f, 1.0f, 0.0f,
+    0.0f, 0.0f, 1.0f
+  };
+  ASSERT_FLOAT_EQ(0.0f, lin::fro(A - lin::identity<float, 3>()));
+  ASSERT_FLOAT_EQ(0.0f, lin::fro(A - lin::identity<lin::Matrix3x3f>()));
+
+  lin::Matrixf<0, 0, 5, 5> B(2, 2);
+  B = lin::identity<lin::Matrixf<0, 0, 5, 5>>(2); // 2x2 output
+  ASSERT_FLOAT_EQ(1.0f, B(0, 0));
+  ASSERT_FLOAT_EQ(0.0f, B(0, 1));
+  ASSERT_FLOAT_EQ(0.0f, B(1, 0));
+  ASSERT_FLOAT_EQ(1.0f, B(1, 1));
+}


### PR DESCRIPTION
Pulling in upstream updates.

### Summary of Changes:
* Added the identity matrix generator function. As an example, a 3x3 identity matrix with flow elements can not be created with either of these function calls:

        #include <lin/core.hpp>
        #include <lin/generators/identity.hpp>
        
        lin::identity<lin::Matrix3x3f>();
        lin::identity<float, 3>();