### PR TITLE
Added the Views Module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,3 +110,16 @@ target_link_libraries(substitutions_tests PRIVATE
   gtest_main
 )
 add_test(run_substitutions_tests substitutions_tests)
+
+add_executable(views_tests
+  test/views/matrix_views_test.cpp
+  test/views/vector_views_test.cpp
+)
+target_include_directories(views_tests PRIVATE
+  include
+)
+target_link_libraries(views_tests PRIVATE
+  gtest
+  gtest_main
+)
+add_test(run_views_tests views_tests)

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -848,6 +848,10 @@ INPUT                  = \
   ../include/lin/core/operations/matrix_operations.hpp \
   ../include/lin/core/operations/vector_operations.hpp \
   ../include/lin/core/operations/tensor_operators.hpp \
+  ../include/lin/views.hpp \
+  ../include/lin/views/tensor_view.hpp \
+  ../include/lin/views/matrix_view.hpp \
+  ../include/lin/views/vector_view.hpp \
   ../include
 
 # This tag can be used to specify the character encoding of the source files

--- a/include/lin.hpp
+++ b/include/lin.hpp
@@ -13,5 +13,6 @@
 #include "lin/queries.hpp"
 #include "lin/references.hpp"
 #include "lin/substitutions.hpp"
+#include "lin/views.hpp"
 
 #endif

--- a/include/lin/core/types/dimensions.hpp
+++ b/include/lin/core/types/dimensions.hpp
@@ -20,18 +20,18 @@ namespace internal {
  *  @tparam D Derived type.
  * 
  *  This functionality is broken out as a separate object so we only include
- *  member variables for tensor dimensions that aren't of a fixed size. There is a
- *  template specialization of this class for each of the following cases:
+ *  member variables for tensor dimensions that aren't of a fixed size. There is
+ *  a template specialization of this class for each of the following cases:
  *
  *   - Fixed rows and columns.
  *   - Fixed rows and strictly bounded columns.
  *   - Strictly bounded rows and fixed columns.
  *   - Strictly bounded rows and columns.
  * 
- *  The specialization for fixed rows and columns, for example, has no additional
- *  member variables while the the specialization for fixed rows and stricly
- *  bounded columns requires one additional member variables to track the number
- *  of columns at runtime.
+ *  The specialization for fixed rows and columns, for example, has no
+ *  additional member variables while the the specialization for fixed rows and
+ *  stricly bounded columns requires one additional member variables to track
+ *  the number of columns at runtime.
  *
  *  @sa internal::Base
  *  @sa internal::has_fixed_rows

--- a/include/lin/core/types/tensor.hpp
+++ b/include/lin/core/types/tensor.hpp
@@ -76,12 +76,12 @@ class Tensor : public Base<D> {
     resize(Traits::max_rows, Traits::max_cols);
   }
 
-  /** @brief Constructs a tensor with zeros initialized elements and the requested
-   *         dimensions.
+  /** @brief Constructs a tensor with zeros initialized elements and the
+   *         requested dimensions.
    *
    *  @param r Initial row dimension.
    *  @param c Initial column dimesnion.
-   * 
+   *
    *  @sa internal::traits
    */
   constexpr Tensor(size_t r, size_t c) {

--- a/include/lin/views.hpp
+++ b/include/lin/views.hpp
@@ -1,0 +1,51 @@
+// vim: set tabstop=2:softtabstop=2:shiftwidth=2:expandtab
+
+/** @file lin/views.hpp
+ *  @author Kyle Krol
+ */
+
+/** @defgroup VIEWS Views
+ *
+ *  @brief Defines the tensor view types which allow raw pointers to be
+ *         interpretted as value backed tensor types.
+ *
+ *  ## Overview
+ * 
+ *  The views module serves one main purpose: to allows external buffers to be
+ *  interpretted as tensor objects within lin.
+ * 
+ *  This may can be extremely helpful, say if you'd like to treat an array from
+ *  the STL with length of three as a three dimensional lin vector. Once you
+ *  create a lin::VectorView3f from it, it'll be compatible with all of lin
+ *  operations and write changes directly back into the original array object.
+ *
+ *  See the following example which treats an array as a three dimensional
+ *  vector and rotates it in place about the z-axis by an angle `alpha`:
+ * 
+ *  ~~~{.cpp}
+ *  #include <lin/core.hpp>
+ *  #include <lin/views.hpp>
+ * 
+ *  #include <array>
+ *  #include <cmath>
+ * 
+ *  void rotate_z(std::array<float, 3> &array, float alpha) {
+ *    lin::VectorView3f v(array.data());
+ *    lin::Matrix3x3f R {
+ *      std::cos(alpha), -std::sin(alpha), 0.0f,
+ *      std::sin(alpha),  std::cos(alpha), 0.0f,
+ *      0.0f,             0.0f,            1.0f
+ *    };
+ *    v = (R * v).eval();
+ *  }
+ *  ~~~
+ */
+
+#ifndef LIN_VIEWS_HPP_
+#define LIN_VIEWS_HPP_
+
+#include "views/matrix_view.hpp"
+#include "views/tensor_view.hpp"
+#include "views/vector_view.hpp"
+
+#endif

--- a/include/lin/views/matrix_view.hpp
+++ b/include/lin/views/matrix_view.hpp
@@ -1,0 +1,134 @@
+// vim: set tabstop=2:softtabstop=2:shiftwidth=2:expandtab
+
+/** @file lin/views/matrix_view.hpp
+ *  @author Kyle Krol
+ */
+
+#ifndef LIN_VIEWS_MATRIX_VIEW_HPP_
+#define LIN_VIEWS_MATRIX_VIEW_HPP_
+
+#include "../core.hpp"
+#include "tensor_view.hpp"
+
+namespace lin {
+
+/** @brief Generic matrix view.
+ * 
+ *  @param T  %Matrix view element type.
+ *  @tparam R  Rows at compile time.
+ *  @tparam C  Columns at compile time.
+ *  @tparam MR Maximum rows at compile time.
+ *  @tparam MC Maximum columns at compile time.
+ * 
+ *  The template parameters specify the matrix view's traits. The traits must
+ *  qualify this type as a matrix.
+ * 
+ *  @sa internal::traits
+ *  @sa internal::is_matrix
+ * 
+ *  @ingroup VIEWS
+ */
+template <typename T, size_t R, size_t C, size_t MR = R, size_t MC = C>
+class MatrixView : public internal::TensorView<MatrixView<T, R, C, MR, MC>> {
+  static_assert(internal::is_matrix<Matrix<T, R, C, MR, MC>>::value,
+      "Invalid MatrixView<...> parameters");
+
+ public:
+  /** @brief Traits information for this type.
+   * 
+   *  @sa internal::traits
+   */
+  typedef internal::traits<MatrixView<T, R, C, MR, MC>> Traits;
+
+ protected:
+  using internal::TensorView<MatrixView<T, R, C, MR, MC>>::derived;
+
+ public:
+  using internal::TensorView<MatrixView<T, R, C, MR, MC>>::TensorView;
+  using internal::TensorView<MatrixView<T, R, C, MR, MC>>::rows;
+  using internal::TensorView<MatrixView<T, R, C, MR, MC>>::cols;
+  using internal::TensorView<MatrixView<T, R, C, MR, MC>>::size;
+  using internal::TensorView<MatrixView<T, R, C, MR, MC>>::data;
+  using internal::TensorView<MatrixView<T, R, C, MR, MC>>::eval;
+  using internal::TensorView<MatrixView<T, R, C, MR, MC>>::resize;
+  using internal::TensorView<MatrixView<T, R, C, MR, MC>>::operator=;
+  using internal::TensorView<MatrixView<T, R, C, MR, MC>>::operator();
+
+  constexpr MatrixView() = default;
+  constexpr MatrixView(MatrixView<T, R, C, MR, MC> const &) = default;
+  constexpr MatrixView(MatrixView<T, R, C, MR, MC> &&) = default;
+  constexpr MatrixView<T, R, C, MR, MC> &operator=(MatrixView<T, R, C, MR, MC> const &) = default;
+  constexpr MatrixView<T, R, C, MR, MC> &operator=(MatrixView<T, R, C, MR, MC> &&) = default;
+};
+
+/** @weakgroup VIEWS
+ *  @{
+ */
+
+/** @brief Generic float matrix view.
+ * 
+ *  @tparam R  Rows at compile time.
+ *  @tparam C  Columns at compile time.
+ *  @tparam MR Maximum rows.
+ *  @tparam MC Maximum columns.
+ * 
+ *  @sa internal::traits
+ *  @sa MatrixView
+ */
+template <size_t R, size_t C, size_t MR = R, size_t MC = C>
+using MatrixViewf = MatrixView<float, R, C, MR, MC>;
+
+typedef MatrixViewf<2, 2> MatrixView2x2f; ///< Two by two float matrix view.
+typedef MatrixViewf<3, 2> MatrixView3x2f; ///< Three by two float matrix view.
+typedef MatrixViewf<4, 2> MatrixView4x2f; ///< Four by two float matrix view.
+typedef MatrixViewf<2, 3> MatrixView2x3f; ///< Two by three float matrix view.
+typedef MatrixViewf<3, 3> MatrixView3x3f; ///< Three by three float matrix view.
+typedef MatrixViewf<4, 3> MatrixView4x3f; ///< Four by three float matrix view.
+typedef MatrixViewf<2, 4> MatrixView2x4f; ///< Two by four float matrix view.
+typedef MatrixViewf<3, 4> MatrixView3x4f; ///< Three by four float matrix view.
+typedef MatrixViewf<4, 4> MatrixView4x4f; ///< Four by four float matrix view.
+
+/** @brief Generic double matrix view.
+ * 
+ *  @tparam R  Rows at compile time.
+ *  @tparam C  Columns at compile time.
+ *  @tparam MR Maximum rows.
+ *  @tparam MC Maximum columns.
+ * 
+ *  @sa internal::traits
+ *  @sa MatrixView
+ */
+template <size_t R, size_t C, size_t MR = R, size_t MC = C>
+using MatrixViewd = MatrixView<double, R, C, MR, MC>;
+
+typedef MatrixViewd<2, 2> MatrixView2x2d; ///< Two by two double matrix view.
+typedef MatrixViewd<3, 2> MatrixView3x2d; ///< Three by two double matrix view.
+typedef MatrixViewd<4, 2> MatrixView4x2d; ///< Four by two double matrix view.
+typedef MatrixViewd<2, 3> MatrixView2x3d; ///< Two by three double matrix view.
+typedef MatrixViewd<3, 3> MatrixView3x3d; ///< Three by three double matrix view.
+typedef MatrixViewd<4, 3> MatrixView4x3d; ///< Four by three double matrix view.
+typedef MatrixViewd<2, 4> MatrixView2x4d; ///< Two by four double matrix view.
+typedef MatrixViewd<3, 4> MatrixView3x4d; ///< Three by four double matrix view.
+typedef MatrixViewd<4, 4> MatrixView4x4d; ///< Four by four double matrix view.
+
+/** @}
+ */
+
+namespace internal {
+
+template <typename T, size_t R, size_t C, size_t MR, size_t MC>
+struct _elem<MatrixView<T, R, C, MR, MC>> {
+  typedef T type;
+};
+
+template <typename T, size_t R, size_t C, size_t MR, size_t MC>
+struct _dims<MatrixView<T, R, C, MR, MC>> {
+  static constexpr size_t rows = R;
+  static constexpr size_t cols = C;
+  static constexpr size_t max_rows = MR;
+  static constexpr size_t max_cols = MC;
+};
+}  // namespace internal
+}  // namespace lin
+
+#endif

--- a/include/lin/views/tensor_view.hpp
+++ b/include/lin/views/tensor_view.hpp
@@ -1,0 +1,119 @@
+// vim: set tabstop=2:softtabstop=2:shiftwidth=2:expandtab
+
+/** @file lin/views/tensor_view.hpp
+ *  @author Kyle Krol
+ */
+
+#ifndef LIN_VIEWS_TENSOR_VIEW_HPP_
+#define LIN_VIEWS_TENSOR_VIEW_HPP_
+
+#include "../core.hpp"
+
+namespace lin {
+namespace internal {
+
+/** @brief Member pointer backed tensor.
+ * 
+ *  @tparam D Derived type.
+ * 
+ *  This allows users to interpret arbitary buffers as tensor objects. The user
+ *  specified buffer is assumed to be at least as large as the tensor's maximum
+ *  size and elements are read and written to the buffer in row major order.
+ *
+ *  @sa internal::Base
+ *  @sa MatrixView
+ *  @sa RowVectorView
+ *  @sa VectorView
+ * 
+ *  @ingroup VIEWS
+ */
+template <class D>
+class TensorView : public internal::Base<D> {
+  static_assert(has_valid_traits<D>::value,
+      "Derived types to Tensor<...> must have valid traits");
+
+ public:
+  /** @brief Traits information for this type.
+   * 
+   *  @sa internal::traits
+   */
+  typedef traits<D> Traits;
+
+ private:
+  typename Traits::elem_t *const elems;
+
+ protected:
+  using Base<D>::derived;
+
+ public:
+  using Base<D>::rows;
+  using Base<D>::cols;
+  using Base<D>::resize;
+  using Base<D>::size;
+  using Base<D>::operator=;
+  using Base<D>::operator();
+  using Base<D>::data;
+  using Base<D>::eval;
+
+  constexpr TensorView(TensorView<D> const &) = default;
+  constexpr TensorView(TensorView<D> &&) = default;
+  constexpr TensorView<D> &operator=(TensorView<D> const &) = default;
+  constexpr TensorView<D> &operator=(TensorView<D> &&) = default;
+
+  /** @brief Constructs a new tensor tensor view with the provided backing
+   *         array.
+   * 
+   *  @param elems Element backing array.
+   * 
+   *  The element backing array is a assumed to be in row major order. Elements
+   *  of the tensor initially hold whatever values were left in the backing
+   *  array.
+   * 
+   *  The backing array should be at least as large as the maximum size of the
+   *  tensor (see internal::traits information).
+   * 
+   *  The size of the tensor defaults to the maximum allowed size.
+   */
+  constexpr TensorView(typename Traits::elem_t *elems)
+  : elems(elems) {
+    resize(Traits::max_rows, Traits::max_cols);
+  }
+
+  /** @brief Constructs a new tensor tensor view with the provided backing
+   *         array and requested dimesnions.
+   *
+   *  @param elems
+   *  @param r     Initial row dimension.
+   *  @param c     Initial column dimesnion.
+   *
+   *  The element backing array is a assumed to be in row major order. Elements
+   *  of the tensor initially hold whatever values were left in the backing
+   *  array.
+   * 
+   *  The backing array should be at least as large as the maximum size of the
+   *  tensor (see internal::traits information).
+   *
+   *  Lin assertions errors will be triggered if the requested dimensions aren't
+   *  possible given the tensor's traits.
+   *
+   *  @sa internal::traits
+   */
+  constexpr TensorView(typename Traits::elem_t *elems, size_t r, size_t c)
+  : elems(elems) {
+    resize(r, c);
+  }
+
+  /** @brief Retrives a pointer to the element backing array.
+   * 
+   *  @returns Pointer to the backing array.
+   * 
+   *  This is the same buffer the tensor view was constructed with.
+   */
+  constexpr typename Traits::elem_t *data() {
+    return elems;
+  }
+};
+}  // namespace internal
+}  // namespace lin
+
+#endif

--- a/include/lin/views/vector_view.hpp
+++ b/include/lin/views/vector_view.hpp
@@ -1,0 +1,283 @@
+// vim: set tabstop=2:softtabstop=2:shiftwidth=2:expandtab
+
+/** @file lin/views/vector_view.hpp
+ *  @author Kyle Krol
+ */
+
+#ifndef LIN_VIEWS_VECTOR_VIEW_HPP_
+#define LIN_VIEWS_VECTOR_VIEW_HPP_
+
+#include "../core.hpp"
+#include "tensor_view.hpp"
+
+namespace lin {
+
+/** @brief Generic vector view.
+ * 
+ *  @tparam T  %Vector view element type.
+ *  @tparam N  Number of elements at compile time (i.e. number of rows).
+ *  @tparam MN Maximum number of elements (i.e. maximum number of rows).
+ * 
+ *  The template parameters specify the vector views's traits. The traits must
+ *  qualify this type as a column vector.
+ * 
+ *  @sa internal::traits
+ *  @sa internal::is_col_vector
+ * 
+ *  @ingroup VIEWS
+ */
+template <typename T, size_t N, size_t MN = N>
+class VectorView : public internal::TensorView<VectorView<T, N, MN>> {
+  static_assert(internal::is_col_vector<VectorView<T, N, MN>>::value,
+      "Invalid VectorView<...> parameters");
+
+ public:
+  /** @brief Traits information for this type.
+   * 
+   *  @sa internal::traits
+   */
+  typedef internal::traits<VectorView<T, N, MN>> Traits;
+
+  /** @brief Vector traits information for this type.
+   * 
+   *  @sa internal::vector_traits
+   */
+  typedef internal::vector_traits<VectorView<T, N, MN>> VectorTraits;
+
+ protected:
+  using internal::TensorView<VectorView<T, N, MN>>::derived;
+
+ public:
+  using internal::TensorView<VectorView<T, N, MN>>::TensorView;
+  using internal::TensorView<VectorView<T, N, MN>>::rows;
+  using internal::TensorView<VectorView<T, N, MN>>::cols;
+  using internal::TensorView<VectorView<T, N, MN>>::size;
+  using internal::TensorView<VectorView<T, N, MN>>::data;
+  using internal::TensorView<VectorView<T, N, MN>>::eval;
+  using internal::TensorView<VectorView<T, N, MN>>::resize;
+  using internal::TensorView<VectorView<T, N, MN>>::operator=;
+  using internal::TensorView<VectorView<T, N, MN>>::operator();
+
+  constexpr VectorView() = default;
+  constexpr VectorView(VectorView<T, N, MN> const &) = default;
+  constexpr VectorView(VectorView<T, N, MN> &&) = default;
+  constexpr VectorView<T, N, MN> &operator=(VectorView<T, N, MN> const &) = default;
+  constexpr VectorView<T, N, MN> &operator=(VectorView<T, N, MN> &&) = default;
+
+  /** @brief Constructs a vector view with the provided backing array and
+   *         requested length.
+   *
+   *  @param elems Element backing array.
+   *  @param n     Initial length.
+   * 
+   *  The backing array should be at least as large as the maximum length of the
+   *  vector (see internal::traits information).
+   * 
+   *  Lin assertion errors will be triggered if the requested length isn't
+   *  possible given the vector view's traits.
+   * 
+   *  @sa internal::has_fixed_rows
+   *  @sa internal::has_strictly_bounded_rows
+   */
+  constexpr VectorView(typename Traits::elem_t *elems, size_t n)
+  : internal::TensorView<VectorView<T, N, MN>>(elems, n, 1) { }
+
+  /** @brief Resizes the vector view's length.
+   *  
+   *  @param n Length.
+   * 
+   *  Lin assertion errors will be triggered if the requested length isn't
+   *  possible given the vector view's traits.
+   * 
+   *  @sa internal::has_fixed_rows
+   *  @sa internal::has_strictly_bounded_rows
+   */
+  constexpr void resize(size_t n) {
+    resize(n, 1);
+  }
+};
+
+/** @brief Generic row vector view.
+ * 
+ *  @tparam T  Row vector element type.
+ *  @tparam N  Number of elements at compile time (i.e. number of rows).
+ *  @tparam MN Maximum number of elements (i.e. maximum number of rows).
+ * 
+ *  The template parameters specify the row vector views's traits. The traits
+ *  must qualify this type as a row vector.
+ * 
+ *  @sa internal::traits
+ *  @sa internal::is_row_vector
+ * 
+ *  @ingroup VIEWS
+ */
+template <typename T, size_t N, size_t MN = N>
+class RowVectorView : public internal::TensorView<RowVectorView<T, N, MN>> {
+  static_assert(internal::is_row_vector<RowVectorView<T, N, MN>>::value,
+      "Invalid RowVectorView<...> parameters");
+
+ public:
+  /** @brief Traits information for this type.
+   * 
+   *  @sa internal::traits
+   */
+  typedef internal::traits<RowVectorView<T, N, MN>> Traits;
+
+  /** @brief Vector traits information for this type.
+   * 
+   *  @sa internal::vector_traits
+   */
+  typedef internal::vector_traits<RowVectorView<T, N, MN>> VectorTraits;
+
+ protected:
+  using internal::TensorView<RowVectorView<T, N, MN>>::derived;
+
+ public:
+  using internal::TensorView<RowVectorView<T, N, MN>>::TensorView;
+  using internal::TensorView<RowVectorView<T, N, MN>>::rows;
+  using internal::TensorView<RowVectorView<T, N, MN>>::cols;
+  using internal::TensorView<RowVectorView<T, N, MN>>::size;
+  using internal::TensorView<RowVectorView<T, N, MN>>::data;
+  using internal::TensorView<RowVectorView<T, N, MN>>::eval;
+  using internal::TensorView<RowVectorView<T, N, MN>>::resize;
+  using internal::TensorView<RowVectorView<T, N, MN>>::operator=;
+  using internal::TensorView<RowVectorView<T, N, MN>>::operator();
+
+  constexpr RowVectorView() = default;
+  constexpr RowVectorView(RowVectorView<T, N, MN> const &) = default;
+  constexpr RowVectorView(RowVectorView<T, N, MN> &&) = default;
+  constexpr RowVectorView<T, N, MN> &operator=(RowVectorView<T, N, MN> const &) = default;
+  constexpr RowVectorView<T, N, MN> &operator=(RowVectorView<T, N, MN> &&) = default;
+
+  /** @brief Constructs a vector view with the provided backing array and
+   *         requested length.
+   *
+   *  @param elems Element backing array.
+   *  @param n     Initial length.
+   * 
+   *  The backing array should be at least as large as the maximum length of the
+   *  row vector (see internal::traits information).
+   * 
+   *  Lin assertion errors will be triggered if the requested length isn't
+   *  possible given the row vector view's traits.
+   * 
+   *  @sa internal::has_fixed_cols
+   *  @sa internal::has_strictly_bounded_cols
+   */
+  constexpr RowVectorView(typename Traits::elem_t *elems, size_t n)
+  : internal::TensorView<RowVectorView<T, N, MN>>(elems, 1, n) { }
+
+  /** @brief Resizes the row vector view's length.
+   *  
+   *  @param n Length.
+   * 
+   *  Lin assertion errors will be triggered if the requested length isn't
+   *  possible given the row vector view's traits.
+   * 
+   *  @sa internal::has_fixed_cols
+   *  @sa internal::has_strictly_bounded_cols
+   */
+  constexpr void resize(size_t n) {
+    resize(1, n);
+  }
+};
+
+/** @weakgroup VIEWS
+ *  @{
+ */
+
+
+/** @brief Generic float vector view.
+ * 
+ *  @tparam N  Length at compile time
+ *  @tparam MN Max length.
+ * 
+ *  @sa internal::traits
+ *  @sa Vector
+ */
+template <size_t N, size_t MN = N>
+using VectorViewf = VectorView<float, N, MN>;
+
+typedef VectorViewf<2> VectorView2f; ///< Two dimensional float vector view.
+typedef VectorViewf<3> VectorView3f; ///< Three dimensional float vector view.
+typedef VectorViewf<4> VectorView4f; ///< Four dimensional float vector view.
+
+/** @brief Generic double vector view.
+ * 
+ *  @tparam N  Length at compile time
+ *  @tparam MN Max length.
+ * 
+ *  @sa internal::traits
+ *  @sa Vector
+ */
+template <size_t N, size_t MN = N>
+using VectorViewd = VectorView<double, N, MN>;
+
+typedef VectorViewd<2> VectorView2d; ///< Two dimensional double vector view.
+typedef VectorViewd<3> VectorView3d; ///< Three dimensional double vector view.
+typedef VectorViewd<4> VectorView4d; ///< Four dimensional double vector view.
+
+/** @brief Generic float row vector view.
+ * 
+ *  @tparam N  Length at compile time
+ *  @tparam MN Max length.
+ * 
+ *  @sa internal::traits
+ *  @sa RowVector
+ */
+template <size_t N, size_t MN = N>
+using RowVectorViewf = RowVectorView<float, N, MN>;
+
+typedef RowVectorViewf<2> RowVectorView2f; ///< Two dimensional float row vector view.
+typedef RowVectorViewf<3> RowVectorView3f; ///< Three dimensional float row vector view.
+typedef RowVectorViewf<4> RowVectorView4f; ///< Four dimensional float row vector view.
+
+/** @brief Generic double row vector view.
+ * 
+ *  @tparam N  Length at compile time
+ *  @tparam MN Max length.
+ * 
+ *  @sa internal::traits
+ *  @sa RowVector
+ */
+template <size_t N, size_t MN = N>
+using RowVectorViewd = RowVectorView<double, N, MN>;
+
+typedef RowVectorViewd<2> RowVectorView2d; ///< Two dimensional double row vector view.
+typedef RowVectorViewd<3> RowVectorView3d; ///< Three dimensional double row vector view.
+typedef RowVectorViewd<4> RowVectorView4d; ///< Four dimensional double row vector view.
+
+/** @}
+ */
+
+namespace internal {
+
+template <typename T, size_t N, size_t MN>
+struct _elem<VectorView<T, N, MN>> {
+  typedef T type;
+};
+
+template <typename T, size_t N, size_t MN>
+struct _dims<VectorView<T, N, MN>> {
+  static constexpr size_t rows = N;
+  static constexpr size_t cols = 1;
+  static constexpr size_t max_rows = MN;
+  static constexpr size_t max_cols = 1;
+};
+
+template <typename T, size_t N, size_t MN>
+struct _elem<RowVectorView<T, N, MN>> {
+  typedef T type;
+};
+
+template <typename T, size_t N, size_t MN>
+struct _dims<RowVectorView<T, N, MN>> {
+  static constexpr size_t rows = 1;
+  static constexpr size_t cols = N;
+  static constexpr size_t max_rows = 1;
+  static constexpr size_t max_cols = MN;
+};
+}  // namespace internal
+}  // namespace lin
+
+#endif

--- a/test/views/matrix_views_test.cpp
+++ b/test/views/matrix_views_test.cpp
@@ -1,0 +1,66 @@
+// vim: set tabstop=2:softtabstop=2:shiftwidth=2:expandtab
+
+#include <lin/core.hpp>
+#include <lin/views/matrix_view.hpp>
+
+#include <gtest/gtest.h>
+
+TEST(MatrixViews, FixedSizeMatrixView) {
+  float buf[9] = {
+    1.0f, 2.0f, 3.0f,
+    4.0f, 5.0f, 6.0f,
+    7.0f, 8.0f, 9.0f
+  };
+
+  lin::MatrixView3x3f A(buf);
+  static_assert(lin::internal::have_same_traits<lin::MatrixView3x3f, lin::Matrix3x3f>::value, "");
+
+  ASSERT_EQ(A.rows(), 3);
+  ASSERT_EQ(A.cols(), 3);
+
+  ASSERT_FLOAT_EQ(A(0, 0), 1.0f);
+  ASSERT_FLOAT_EQ(A(0, 1), 2.0f);
+  ASSERT_FLOAT_EQ(A(0, 2), 3.0f);
+  ASSERT_FLOAT_EQ(A(1, 0), 4.0f);
+  ASSERT_FLOAT_EQ(A(1, 1), 5.0f);
+  ASSERT_FLOAT_EQ(A(1, 2), 6.0f);
+  ASSERT_FLOAT_EQ(A(2, 0), 7.0f);
+  ASSERT_FLOAT_EQ(A(2, 1), 8.0f);
+  ASSERT_FLOAT_EQ(A(2, 2), 9.0f);
+
+  A(1, 1) = 10.0f;
+  ASSERT_FLOAT_EQ(buf[4], 10.0f);
+
+  ASSERT_EQ(A.data(), buf);
+}
+
+TEST(MatrixViews, VariableSizeMatrixView) {
+  float buf[9] = {
+    1.0f, 2.0f, 3.0f,
+    4.0f, 5.0f, 6.0f,
+    7.0f, 8.0f, 9.0f
+  };
+
+  lin::MatrixViewf<0, 0, 3, 3> A(buf, 2, 2);
+  static_assert(lin::internal::have_same_traits<lin::Matrixf<0, 0, 3, 3>, lin::MatrixViewf<0, 0, 3, 3>>::value, "");
+
+  ASSERT_EQ(A.rows(), 2);
+  ASSERT_EQ(A.cols(), 2);
+
+  ASSERT_FLOAT_EQ(A(0, 0), 1.0f);
+  ASSERT_FLOAT_EQ(A(0, 1), 2.0f);
+  ASSERT_FLOAT_EQ(A(1, 0), 3.0f);
+  ASSERT_FLOAT_EQ(A(1, 1), 4.0f);
+
+  A(1, 1) = 10.0f;
+  ASSERT_FLOAT_EQ(buf[3], 10.0f);
+
+  A.resize(3, 2);
+  ASSERT_EQ(A.rows(), 3);
+  ASSERT_EQ(A.cols(), 2);
+
+  A(2, 1) = 20.0f;
+  ASSERT_FLOAT_EQ(buf[5], 20.0f);
+
+  ASSERT_EQ(A.data(), buf);
+}

--- a/test/views/vector_views_test.cpp
+++ b/test/views/vector_views_test.cpp
@@ -1,0 +1,127 @@
+// vim: set tabstop=2:softtabstop=2:shiftwidth=2:expandtab
+
+#include <lin/core.hpp>
+#include <lin/views/vector_view.hpp>
+
+#include <gtest/gtest.h>
+
+TEST(VectorViews, FixedSizeVectorView) {
+  float buf[3];
+
+  buf[0] = 1.0f;
+  buf[1] = 2.0f;
+  buf[2] = 3.0f;
+  lin::VectorView3f a(buf);
+
+  // Check traits are correct
+  static_assert(lin::internal::have_same_traits<lin::Vector3f, lin::VectorView3f>::value, "");
+
+  // Check dimesnions
+  ASSERT_EQ(a.rows(), 3);
+  ASSERT_EQ(a.cols(), 1);
+
+  // Check elements are correct
+  ASSERT_FLOAT_EQ(a(0), 1.0f);
+  ASSERT_FLOAT_EQ(a(1), 2.0f);
+  ASSERT_FLOAT_EQ(a(2), 3.0f);
+
+  // Test changes are reflected in the original buffer
+  a(1) = 4.0f;
+  ASSERT_FLOAT_EQ(buf[1], 4.0f);
+
+  // Test the correct buffer is returned
+  ASSERT_EQ(a.data(), buf);
+}
+
+TEST(VectorViews, FixedSizeRowVectorView) {
+  float buf[3];
+
+  buf[0] = 1.0f;
+  buf[1] = 2.0f;
+  buf[2] = 3.0f;
+  lin::RowVectorView3f a(buf);
+
+  // Check traits are correct
+  static_assert(lin::internal::have_same_traits<lin::RowVector3f, lin::RowVectorView3f>::value, "");
+
+  // Check dimesnions
+  ASSERT_EQ(a.rows(), 1);
+  ASSERT_EQ(a.cols(), 3);
+
+  // Check elements are correct
+  ASSERT_FLOAT_EQ(a(0), 1.0f);
+  ASSERT_FLOAT_EQ(a(1), 2.0f);
+  ASSERT_FLOAT_EQ(a(2), 3.0f);
+
+  // Test changes are reflected in the original buffer
+  a(1) = 4.0f;
+  ASSERT_FLOAT_EQ(buf[1], 4.0f);
+}
+
+TEST(VectorViews, VariableSizeVectorView) {
+  double buf[6];
+
+  buf[0] = 1.0;
+  buf[1] = 2.0;
+  buf[2] = 3.0;
+  buf[3] = 4.0;
+  lin::VectorViewd<0, 6> a(buf, 4);
+
+  // Check traits are correct
+  static_assert(lin::internal::have_same_traits<lin::Vectord<0, 6>, lin::VectorViewd<0, 6>>::value, "");
+
+  // Check dimesnions
+  ASSERT_EQ(a.rows(), 4);
+  ASSERT_EQ(a.cols(), 1);
+
+  // Check elements are correct
+  ASSERT_DOUBLE_EQ(a(0), 1.0);
+  ASSERT_DOUBLE_EQ(a(1), 2.0);
+  ASSERT_DOUBLE_EQ(a(2), 3.0);
+  ASSERT_DOUBLE_EQ(a(3), 4.0);
+
+  // Test changes are reflected in the original buffer
+  a(1) = 4.0;
+  ASSERT_DOUBLE_EQ(buf[1], 4.0);
+
+  // Test resize
+  a.resize(6);
+  a(5) = 10.0;
+  ASSERT_EQ(a.rows(), 6);
+  ASSERT_DOUBLE_EQ(buf[5], 10.0);
+
+  // Test the correct buffer is returned
+  ASSERT_EQ(a.data(), buf);
+}
+
+TEST(VectorViews, VariableSizeRowVectorView) {
+  double buf[6];
+
+  buf[0] = 1.0;
+  buf[1] = 2.0;
+  lin::RowVectorViewd<0, 6> a(buf, 2);
+
+  // Check traits are correct
+  static_assert(lin::internal::have_same_traits<lin::RowVectord<0, 6>, lin::RowVectorViewd<0, 6>>::value, "");
+
+  // Check dimesnions
+  ASSERT_EQ(a.rows(), 1);
+  ASSERT_EQ(a.cols(), 2);
+
+  // Check elements are correct
+  ASSERT_DOUBLE_EQ(a(0), 1.0);
+  ASSERT_DOUBLE_EQ(a(1), 2.0);
+
+  // Test changes are reflected in the original buffer
+  a(1) = 4.0;
+  ASSERT_DOUBLE_EQ(buf[1], 4.0);
+
+  // Test resize
+  a.resize(5);
+  a(4) = 10.0;
+  ASSERT_EQ(a.cols(), 5);
+  ASSERT_DOUBLE_EQ(buf[4], 10.0);
+
+  // Test the correct buffer is returned
+  ASSERT_EQ(a.data(), buf);
+}


### PR DESCRIPTION
You can pull this module in with:

    #include <lin/core.hpp>
    #include <lin/views.hpp>

This adds that allow you to provide the element backing buffer yourself with a pointer to some array. So you can do something like this:

    void normalize_vec3(float *fs) {  // fs needs to point to an array of at least 3 floats
      lin::VectorView3f v(fs);
      v = v / lin::norm(v);
    }

and the changes will be updated in the array pointed to by `fs`.

The `*View*` objects should be compatible will all other lin operations.