### PR TITLE
Update library.json to prevent PIO from trying to compiler a library

### DIFF
--- a/library.json
+++ b/library.json
@@ -3,7 +3,8 @@
     "version": "0.0.1",
     "license": "MIT",
     "build": {
-        "includeDir": "include"
+        "includeDir": "include",
+        "libArchive": false
     },
     "repository": {
         "type": "git",

--- a/library.json
+++ b/library.json
@@ -11,3 +11,4 @@
         "url": "https://github.com/kkrol27/lin.git"
     }
 }
+

--- a/library.json
+++ b/library.json
@@ -11,4 +11,3 @@
         "url": "https://github.com/kkrol27/lin.git"
     }
 }
-


### PR DESCRIPTION
Part of fixing [this issue](https://github.com/pathfinder-for-autonomous-navigation/psim/issues/257) from the PSim repository.