### PR TITLE
Fix Reorder Warning

### DIFF
--- a/include/lin/generators/randoms.hpp
+++ b/include/lin/generators/randoms.hpp
@@ -53,8 +53,8 @@ class RandomsGenerator {
    */
   constexpr RandomsGenerator(unsigned long long seed = 0) : 
     seed(seed ^ 4101842887655102017LL), 
-    has_cached(false),
-    cached_rand(0.0) { }
+    cached_rand(0.0),
+    has_cached(false) { }
 
   /** @brief Generates a uniform random number in the range zero to one.
    * 


### PR DESCRIPTION
Saw this warning in a PSim CI build:

```
In file included from lib/lin/include/lin/generators.hpp:20:0,
                 from test/gnc/orbit_controller/test_orbit_controller.cpp:6:
lib/lin/include/lin/generators/randoms.hpp: In constructor ‘constexpr lin::internal::RandomsGenerator::RandomsGenerator(long long unsigned int)’:
lib/lin/include/lin/generators/randoms.hpp:42:8: error: ‘lin::internal::RandomsGenerator::has_cached’ will be initialized after [-Werror=reorder]
   bool has_cached;
        ^~~~~~~~~~
lib/lin/include/lin/generators/randoms.hpp:36:10: error:   ‘double lin::internal::RandomsGenerator::cached_rand’ [-Werror=reorder]
   double cached_rand;
          ^~~~~~~~~~~
lib/lin/include/lin/generators/randoms.hpp:54:13: error:   when initialized here [-Werror=reorder]
   constexpr RandomsGenerator(unsigned long long seed = 0) :
             ^~~~~~~~~~~~~~~~
```