### PR TITLE
Updates for Python 3.9.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -468,7 +468,7 @@ setup(
     description='Simple python wrapper for lin matrix and vector types.',
     long_description='',
     ext_modules=ext_modules,
-    setup_requires=['pybind11>=2.5.0'],
+    setup_requires=['pybind11>=2.6.0'],
     install_requires=['numpy'],
     cmdclass={'build_ext': BuildExt},
     zip_safe=False,


### PR DESCRIPTION
Per the issue described [here](https://github.com/python/cpython/pull/22670), pybind11 needed to create a workaround for Python 3.9.0 to avoid crashes (see the pybind11 github README for more information).

This updates the pybind11 version used to include the Python 3.9.0 workaround.