### PR TITLE
Square Brackets Operator

### DIFF
--- a/include/lin/core/types/mapping.hpp
+++ b/include/lin/core/types/mapping.hpp
@@ -119,6 +119,32 @@ class Mapping : public Stream<D> {
     return const_cast<D &>(derived())(i);
   }
 
+  /** @brief Provides read and write access to tensor elements.
+   *
+   *  @param i Index
+   *
+   *  @return Reference to the tensor element.
+   *
+   *  Element access proceeds as if all the elements of the tensor stream were
+   *  flattened into an array in row major order.
+   */
+  inline constexpr typename Traits::elem_t &operator[](size_t i) {
+    return derived()(i);
+  }
+
+  /** @brief Provides read only access to tensor elements.
+   *
+   *  @param i Index.
+   *
+   *  @return Value of the tensor elements.
+   *
+   *  Element access proceeds as if all the elements of the tensor stream were
+   *  flattened into an array in row major order.
+   */
+  inline constexpr typename Traits::elem_t operator[](size_t i) const {
+    return const_cast<D &>(derived())(i);
+  }
+
   /** @brief Copy an initializer list's elements into the tensor's elements.
    * 
    *  @param list Initializer list.

--- a/include/lin/core/types/stream.hpp
+++ b/include/lin/core/types/stream.hpp
@@ -125,6 +125,24 @@ class Stream {
     return derived()(i);
   }
 
+  /** @brief Provides read only access to tensor elements.
+   *
+   *  @param i Index.
+   *
+   *  @return Value of the tensor elements.
+   *
+   *  Element access proceeds as if all the elements of the tensor stream were
+   *  flattened into an array in row major order.
+   *
+   *  If accessing data from a lazily evaluation tensor operation, you may want to
+   *  consider for the creation of a value backed type to reduce overhead.
+   *
+   *  @sa internal::Stream::eval
+   */
+  inline constexpr typename Traits::elem_t operator[](size_t i) const {
+    return derived()(i);
+	}
+
   /** @brief Forces evaluation of this stream to a value backed type.
    * 
    *  @returns Resulting value.

--- a/include/lin/core/types/stream.hpp
+++ b/include/lin/core/types/stream.hpp
@@ -141,7 +141,7 @@ class Stream {
    */
   inline constexpr typename Traits::elem_t operator[](size_t i) const {
     return derived()(i);
-	}
+  }
 
   /** @brief Forces evaluation of this stream to a value backed type.
    * 


### PR DESCRIPTION
Introduced the square brackets operator for traditional, array style access to tensor elements assuming a row major order.

The primary advantage here is more compatibility with the `std::array` class. My main thought here is easier `sympy` automatic code generation which will be required for the some orbit estimation implementations.