### PR TITLE
Add Const Views to the Views Module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ __pycache__
 .pytest_cache
 lin.cpp
 bazel-*
+compile_commands.json

--- a/include/lin/core/types.hpp
+++ b/include/lin/core/types.hpp
@@ -16,6 +16,7 @@
 #define LIN_CORE_TYPES_HPP_
 
 #include "types/base.hpp"
+#include "types/const_base.hpp"
 #include "types/dimensions.hpp"
 #include "types/mapping.hpp"
 #include "types/matrix.hpp"

--- a/include/lin/core/types/const_base.hpp
+++ b/include/lin/core/types/const_base.hpp
@@ -1,21 +1,21 @@
 // vim: set tabstop=2:softtabstop=2:shiftwidth=2:expandtab
 
-/** @file lin/core/types/base.hpp
+/** @file lin/core/types/const_base.hpp
  *  @author Kyle Krol
  */
 
-#ifndef LIN_CORE_TYPES_BASE_HPP_
-#define LIN_CORE_TYPES_BASE_HPP_
+#ifndef LIN_CORE_TYPES_CONST_BASE_HPP_
+#define LIN_CORE_TYPES_CONST_BASE_HPP_
 
 #include "../config.hpp"
 #include "../traits.hpp"
 #include "dimensions.hpp"
-#include "mapping.hpp"
+#include "stream.hpp"
 
 namespace lin {
 namespace internal {
 
-/** @brief Value backed tensor interface with resizing support.
+/** @brief Value backed, read only tensor interface.
  * 
  *  @tparam D Derived type.
  * 
@@ -26,8 +26,8 @@ namespace internal {
  *  added. A getter to retrive a pointer to the element backing array is also
  *  included.
  * 
- *  The main purpose is to provide an interface that supports value backed types
- *  - i.e. those directly storing tensor elements in a member array or and a
+ *  The main purpose is to provide an interface that supports value backed types -
+ *  i.e. those directly storing tensor elements in a member array or and a
  *  pointer.
  * 
  *  @sa internal::Stream
@@ -37,9 +37,9 @@ namespace internal {
  *  @ingroup CORETYPES
  */
 template <class D>
-class Base : public Mapping<D>, public Dimensions<D> {
+class ConstBase : public Stream<D>, public Dimensions<D> {
   static_assert(has_valid_traits<D>::value,
-      "Derived types to Base<...> must have valid traits");
+      "Derived types to ConstBase<...> must have valid traits");
 
  public:
   /** @brief Traits information for this type.
@@ -49,34 +49,22 @@ class Base : public Mapping<D>, public Dimensions<D> {
   typedef traits<D> Traits;
 
  protected:
-  using Mapping<D>::derived;
+  using Stream<D>::derived;
 
  public:
-  using Mapping<D>::size;
-  using Mapping<D>::eval;
-  using Mapping<D>::operator=;
-  using Mapping<D>::operator();
+  using Stream<D>::size;
+  using Stream<D>::eval;
+  using Stream<D>::operator();
 
   using Dimensions<D>::rows;
   using Dimensions<D>::cols;
   using Dimensions<D>::resize;
 
-  constexpr Base() = default;
-  constexpr Base(Base<D> const &) = default;
-  constexpr Base(Base<D> &&) = default;
-  constexpr Base<D> &operator=(Base<D> const &) = default;
-  constexpr Base<D> &operator=(Base<D> &&) = default;
-
-  /** @brief Retrives a pointer to the element backing array.
-   * 
-   *  @returns Pointer to the backing array.
-   * 
-   *  The elements of the tensor are layed out in row major order in the backing
-   *  array. They are stored contiguously in memory.
-   */
-  inline constexpr typename Traits::elem_t *data() {
-    return derived().data();
-  }
+  constexpr ConstBase() = default;
+  constexpr ConstBase(ConstBase<D> const &) = default;
+  constexpr ConstBase(ConstBase<D> &&) = default;
+  constexpr ConstBase<D> &operator=(ConstBase<D> const &) = default;
+  constexpr ConstBase<D> &operator=(ConstBase<D> &&) = default;
 
   /** @brief Retrives a constant pointer to the element backing array.
    * 
@@ -86,31 +74,31 @@ class Base : public Mapping<D>, public Dimensions<D> {
    *  array. They are stored contiguously in memory.
    */
   inline constexpr typename Traits::elem_t const *data() const {
-    return const_cast<D &>(derived()).data();
+    return derived().data();
   }
 
-  /** @brief Provides read and write access to tensor elements.
+  /** @brief Provides read only access to tensor elements.
    * 
    *  @param i Row index.
    *  @param j Column index.
    * 
-   *  @return Reference to the tensor element.
+   *  @return Value of the tensor element.
    * 
    *  If the indices are out of bounds as defined by the tensor's current
    *  dimensions, lin assertion errors will be triggered.
    */
-  constexpr typename Traits::elem_t &operator()(size_t i, size_t j) {
+  constexpr typename Traits::elem_t const &operator()(size_t i, size_t j) const {
     LIN_ASSERT(0 <= i && i < rows());
     LIN_ASSERT(0 <= j && j < cols());
 
     return data()[i * cols() + j];
   }
 
-  /** @brief Provides read and write access to tensor elements.
+  /** @brief Provides read only access to tensor elements.
    * 
    *  @param i Index
    * 
-   *  @return Reference to the tensor element.
+   *  @return Value of the tensor element.
    * 
    *  Element access proceeds as if all the elements of the tensor stream were
    *  flattened into an array in row major order.
@@ -118,7 +106,7 @@ class Base : public Mapping<D>, public Dimensions<D> {
    *  If the index is out of bounds as defined by the tensor's current size, lin
    *  lin assertion errors will be triggered.
    */
-  constexpr typename Traits::elem_t &operator()(size_t i) {
+  constexpr typename Traits::elem_t const &operator()(size_t i) {
     LIN_ASSERT(0 <= i && i < size());
 
     return data()[i];

--- a/include/lin/views.hpp
+++ b/include/lin/views.hpp
@@ -41,7 +41,7 @@
  *  }
  *  ~~~
  *
- *  It's important to note that their are actually two types of views that can
+ *  It's important to note that there are actually two types of views that can
  *  be returned by lin::view. The first is a standard view which allows read and
  *  write access to the underlying elements (this is seen in the example above).
  *  The second is known as a constant view and only allows read access to the

--- a/include/lin/views.hpp
+++ b/include/lin/views.hpp
@@ -5,20 +5,21 @@
  */
 
 /** @defgroup VIEWS Views
- *
- *  @brief Defines the tensor view types which allow raw pointers to be
- *         interpretted as value backed tensor types.
- *
+ * 
+ *  @brief Allows arbitrary data buffers to be interpreted as value backed
+ *         tensor types.
+ * 
  *  ## Overview
  * 
  *  The views module serves one main purpose: to allows external buffers to be
  *  interpretted as tensor objects within lin.
- * 
- *  This may can be extremely helpful, say if you'd like to treat an array from
- *  the STL with length of three as a three dimensional lin vector. Once you
- *  create a lin::VectorView3f from it, it'll be compatible with all of lin
- *  operations and write changes directly back into the original array object.
  *
+ *  This can be extremely helpful, say for example, if you'd like to treat an
+ *  array from the STL as a three dimensional vector and perform some operations
+ *  in a function to mutate it. All that's required is to use the lin::view
+ *  function to create a vector view and then leverage the rest of the lin
+ *  library.
+ * 
  *  See the following example which treats an array as a three dimensional
  *  vector and rotates it in place about the z-axis by an angle `alpha`:
  * 
@@ -30,8 +31,8 @@
  *  #include <cmath>
  * 
  *  void rotate_z(std::array<float, 3> &array, float alpha) {
- *    lin::VectorView3f v(array.data());
- *    lin::Matrix3x3f R {
+ *    auto v = lin::view<lin::Vector3f>(array.data());
+ *    lin::Matrix3x3f R = {
  *      std::cos(alpha), -std::sin(alpha), 0.0f,
  *      std::sin(alpha),  std::cos(alpha), 0.0f,
  *      0.0f,             0.0f,            1.0f
@@ -39,13 +40,24 @@
  *    v = (R * v).eval();
  *  }
  *  ~~~
+ *
+ *  It's important to note that their are actually two types of views that can
+ *  be returned by lin::view. The first is a standard view which allows read and
+ *  write access to the underlying elements (this is seen in the example above).
+ *  The second is known as a constant view and only allows read access to the
+ *  underlying elements. This is done automatically if the buffer passed to
+ *  lin::view points to const elements.
  */
 
 #ifndef LIN_VIEWS_HPP_
 #define LIN_VIEWS_HPP_
 
+#include "views/const_matrix_view.hpp"
+#include "views/const_tensor_view.hpp"
+#include "views/const_vector_view.hpp"
 #include "views/matrix_view.hpp"
 #include "views/tensor_view.hpp"
 #include "views/vector_view.hpp"
+#include "views/view.hpp"
 
 #endif

--- a/include/lin/views/const_matrix_view.hpp
+++ b/include/lin/views/const_matrix_view.hpp
@@ -1,0 +1,79 @@
+// vim: set tabstop=2:softtabstop=2:shiftwidth=2:expandtab
+
+/** @file lin/views/const_matrix_view.hpp
+ *  @author Kyle Krol
+ */
+
+#ifndef LIN_VIEWS_CONST_MATRIX_VIEW_HPP_
+#define LIN_VIEWS_CONST_MATRIX_VIEW_HPP_
+
+#include "../core.hpp"
+#include "const_tensor_view.hpp"
+
+namespace lin {
+namespace internal {
+
+/** @brief Generic constant matrix view.
+ * 
+ *  @tparam T  Constant matrix view element type.
+ *  @tparam R  Rows at compile time.
+ *  @tparam C  Columns at compile time.
+ *  @tparam MR Maximum rows at compile time.
+ *  @tparam MC Maximum columns at compile time.
+ * 
+ *  The template parameters specify the matrix view's traits. The traits must
+ *  qualify this type as a matrix.
+ * 
+ *  @sa internal::traits
+ *  @sa internal::is_matrix
+ * 
+ *  @ingroup VIEWS
+ */
+template <typename T, size_t R, size_t C, size_t MR = R, size_t MC = C>
+class ConstMatrixView : public ConstTensorView<ConstMatrixView<T, R, C, MR, MC>> {
+  static_assert(is_matrix<Matrix<T, R, C, MR, MC>>::value,
+      "Invalid ConstMatrixView<...> parameters");
+
+ public:
+  /** @brief Traits information for this type.
+   * 
+   *  @sa internal::traits
+   */
+  typedef traits<ConstMatrixView<T, R, C, MR, MC>> Traits;
+
+ protected:
+  using ConstTensorView<ConstMatrixView<T, R, C, MR, MC>>::derived;
+
+ public:
+  using ConstTensorView<ConstMatrixView<T, R, C, MR, MC>>::ConstTensorView;
+  using ConstTensorView<ConstMatrixView<T, R, C, MR, MC>>::rows;
+  using ConstTensorView<ConstMatrixView<T, R, C, MR, MC>>::cols;
+  using ConstTensorView<ConstMatrixView<T, R, C, MR, MC>>::size;
+  using ConstTensorView<ConstMatrixView<T, R, C, MR, MC>>::data;
+  using ConstTensorView<ConstMatrixView<T, R, C, MR, MC>>::eval;
+  using ConstTensorView<ConstMatrixView<T, R, C, MR, MC>>::resize;
+  using ConstTensorView<ConstMatrixView<T, R, C, MR, MC>>::operator();
+
+  constexpr ConstMatrixView() = delete;
+  constexpr ConstMatrixView(ConstMatrixView<T, R, C, MR, MC> const &) = default;
+  constexpr ConstMatrixView(ConstMatrixView<T, R, C, MR, MC> &&) = default;
+  constexpr ConstMatrixView<T, R, C, MR, MC> &operator=(ConstMatrixView<T, R, C, MR, MC> const &) = default;
+  constexpr ConstMatrixView<T, R, C, MR, MC> &operator=(ConstMatrixView<T, R, C, MR, MC> &&) = default;
+};
+
+template <typename T, size_t R, size_t C, size_t MR, size_t MC>
+struct _elem<ConstMatrixView<T, R, C, MR, MC>> {
+  typedef T type;
+};
+
+template <typename T, size_t R, size_t C, size_t MR, size_t MC>
+struct _dims<ConstMatrixView<T, R, C, MR, MC>> {
+  static constexpr size_t rows = R;
+  static constexpr size_t cols = C;
+  static constexpr size_t max_rows = MR;
+  static constexpr size_t max_cols = MC;
+};
+}  // namespace internal
+}  // namespace lin
+
+#endif

--- a/include/lin/views/const_tensor_view.hpp
+++ b/include/lin/views/const_tensor_view.hpp
@@ -21,9 +21,9 @@ namespace internal {
  *  size and elements are read and written to the buffer in row major order.
  *
  *  @sa internal::ConstBase
- *  @sa ConstMatrixView
- *  @sa ConstRowVectorView
- *  @sa ConstVectorView
+ *  @sa internal::ConstMatrixView
+ *  @sa internal::ConstRowVectorView
+ *  @sa internal::ConstVectorView
  * 
  *  @ingroup VIEWS
  */
@@ -60,7 +60,7 @@ class ConstTensorView : public ConstBase<D> {
   constexpr ConstTensorView<D> &operator=(ConstTensorView<D> &&) = default;
 
   /** @brief Constructs a new constant tensor tensor view with the provided
-   *         backin array.
+   *         backing array.
    * 
    *  @param elems Constant element backing array.
    * 

--- a/include/lin/views/const_tensor_view.hpp
+++ b/include/lin/views/const_tensor_view.hpp
@@ -4,15 +4,15 @@
  *  @author Kyle Krol
  */
 
-#ifndef LIN_VIEWS_TENSOR_VIEW_HPP_
-#define LIN_VIEWS_TENSOR_VIEW_HPP_
+#ifndef LIN_VIEWS_CONST_TENSOR_VIEW_HPP_
+#define LIN_VIEWS_CONST_TENSOR_VIEW_HPP_
 
 #include "../core.hpp"
 
 namespace lin {
 namespace internal {
 
-/** @brief Member pointer backed tensor.
+/** @brief Member pointer backed constant tensor.
  * 
  *  @tparam D Derived type.
  * 
@@ -20,17 +20,17 @@ namespace internal {
  *  specified buffer is assumed to be at least as large as the tensor's maximum
  *  size and elements are read and written to the buffer in row major order.
  *
- *  @sa internal::Base
- *  @sa MatrixView
- *  @sa RowVectorView
- *  @sa VectorView
+ *  @sa internal::ConstBase
+ *  @sa ConstMatrixView
+ *  @sa ConstRowVectorView
+ *  @sa ConstVectorView
  * 
  *  @ingroup VIEWS
  */
 template <class D>
-class TensorView : public Base<D> {
+class ConstTensorView : public ConstBase<D> {
   static_assert(has_valid_traits<D>::value,
-      "Derived types to Tensor<...> must have valid traits");
+      "Derived types to ConstTensor<...> must have valid traits");
 
  public:
   /** @brief Traits information for this type.
@@ -40,31 +40,29 @@ class TensorView : public Base<D> {
   typedef traits<D> Traits;
 
  private:
-  typename Traits::elem_t *const elems;
+  typename Traits::elem_t const *const elems;
 
  protected:
-  using Base<D>::derived;
+  using ConstBase<D>::derived;
 
  public:
-  using Base<D>::rows;
-  using Base<D>::cols;
-  using Base<D>::resize;
-  using Base<D>::size;
-  using Base<D>::operator=;
-  using Base<D>::operator();
-  using Base<D>::data;
-  using Base<D>::eval;
+  using ConstBase<D>::rows;
+  using ConstBase<D>::cols;
+  using ConstBase<D>::resize;
+  using ConstBase<D>::size;
+  using ConstBase<D>::operator();
+  using ConstBase<D>::eval;
 
-  constexpr TensorView() = delete;
-  constexpr TensorView(TensorView<D> const &) = default;
-  constexpr TensorView(TensorView<D> &&) = default;
-  constexpr TensorView<D> &operator=(TensorView<D> const &) = default;
-  constexpr TensorView<D> &operator=(TensorView<D> &&) = default;
+  constexpr ConstTensorView() = delete;
+  constexpr ConstTensorView(ConstTensorView<D> const &) = default;
+  constexpr ConstTensorView(ConstTensorView<D> &&) = default;
+  constexpr ConstTensorView<D> &operator=(ConstTensorView<D> const &) = default;
+  constexpr ConstTensorView<D> &operator=(ConstTensorView<D> &&) = default;
 
-  /** @brief Constructs a new tensor tensor view with the provided backing
-   *         array.
+  /** @brief Constructs a new constant tensor tensor view with the provided
+   *         backin array.
    * 
-   *  @param elems Element backing array.
+   *  @param elems Constant element backing array.
    * 
    *  The element backing array is a assumed to be in row major order. Elements
    *  of the tensor initially hold whatever values were left in the backing
@@ -75,15 +73,15 @@ class TensorView : public Base<D> {
    * 
    *  The size of the tensor defaults to the maximum allowed size.
    */
-  constexpr TensorView(typename Traits::elem_t *elems)
+  constexpr ConstTensorView(typename Traits::elem_t const *elems)
   : elems(elems) {
     resize(Traits::max_rows, Traits::max_cols);
   }
 
-  /** @brief Constructs a new tensor tensor view with the provided backing
-   *         array and requested dimensions.
+  /** @brief Constructs a new constant tensor tensor view with the provided
+   *         backing array and requested dimensions.
    *
-   *  @param elems Element backing array.
+   *  @param elems Constant element backing array.
    *  @param r     Initial row dimension.
    *  @param c     Initial column dimension.
    *
@@ -99,18 +97,18 @@ class TensorView : public Base<D> {
    *
    *  @sa internal::traits
    */
-  constexpr TensorView(typename Traits::elem_t *elems, size_t r, size_t c)
+  constexpr ConstTensorView(typename Traits::elem_t const *elems, size_t r, size_t c)
   : elems(elems) {
     resize(r, c);
   }
 
-  /** @brief Retrives a pointer to the element backing array.
+  /** @brief Retrives a constant pointer to the element backing array.
    * 
-   *  @returns Pointer to the backing array.
+   *  @returns Constant pointer to the backing array.
    * 
    *  This is the same buffer the tensor view was constructed with.
    */
-  constexpr typename Traits::elem_t *data() {
+  constexpr typename Traits::elem_t const *data() const {
     return elems;
   }
 };

--- a/include/lin/views/const_tensor_view.hpp
+++ b/include/lin/views/const_tensor_view.hpp
@@ -1,6 +1,6 @@
 // vim: set tabstop=2:softtabstop=2:shiftwidth=2:expandtab
 
-/** @file lin/views/tensor_view.hpp
+/** @file lin/views/const_tensor_view.hpp
  *  @author Kyle Krol
  */
 

--- a/include/lin/views/const_vector_view.hpp
+++ b/include/lin/views/const_vector_view.hpp
@@ -1,0 +1,213 @@
+// vim: set tabstop=2:softtabstop=2:shiftwidth=2:expandtab
+
+/** @file lin/views/const_vector_view.hpp
+ *  @author Kyle Krol
+ */
+
+#ifndef LIN_VIEWS_CONST_VECTOR_VIEW_HPP_
+#define LIN_VIEWS_CONST_VECTOR_VIEW_HPP_
+
+#include "../core.hpp"
+#include "const_tensor_view.hpp"
+
+namespace lin {
+namespace internal {
+
+/** @brief Generic constant vector view.
+ * 
+ *  @tparam T  Constant vector view element type.
+ *  @tparam N  Number of elements at compile time (i.e. number of rows).
+ *  @tparam MN Maximum number of elements (i.e. maximum number of rows).
+ * 
+ *  The template parameters specify the vector views's traits. The traits must
+ *  qualify this type as a column vector.
+ * 
+ *  @sa internal::traits
+ *  @sa internal::is_col_vector
+ * 
+ *  @ingroup VIEWS
+ */
+template <typename T, size_t N, size_t MN = N>
+class ConstVectorView : public ConstTensorView<ConstVectorView<T, N, MN>> {
+  static_assert(is_col_vector<ConstVectorView<T, N, MN>>::value,
+      "Invalid ConstVectorView<...> parameters");
+
+ public:
+  /** @brief Traits information for this type.
+   * 
+   *  @sa internal::traits
+   */
+  typedef traits<ConstVectorView<T, N, MN>> Traits;
+
+  /** @brief Vector traits information for this type.
+   * 
+   *  @sa internal::vector_traits
+   */
+  typedef vector_traits<ConstVectorView<T, N, MN>> VectorTraits;
+
+ protected:
+  using ConstTensorView<ConstVectorView<T, N, MN>>::derived;
+
+ public:
+  using ConstTensorView<ConstVectorView<T, N, MN>>::ConstTensorView;
+  using ConstTensorView<ConstVectorView<T, N, MN>>::rows;
+  using ConstTensorView<ConstVectorView<T, N, MN>>::cols;
+  using ConstTensorView<ConstVectorView<T, N, MN>>::size;
+  using ConstTensorView<ConstVectorView<T, N, MN>>::data;
+  using ConstTensorView<ConstVectorView<T, N, MN>>::eval;
+  using ConstTensorView<ConstVectorView<T, N, MN>>::resize;
+  using ConstTensorView<ConstVectorView<T, N, MN>>::operator();
+
+  constexpr ConstVectorView() = delete;
+  constexpr ConstVectorView(ConstVectorView<T, N, MN> const &) = default;
+  constexpr ConstVectorView(ConstVectorView<T, N, MN> &&) = default;
+  constexpr ConstVectorView<T, N, MN> &operator=(ConstVectorView<T, N, MN> const &) = default;
+  constexpr ConstVectorView<T, N, MN> &operator=(ConstVectorView<T, N, MN> &&) = default;
+
+  /** @brief Constructs a constant vector view with the provided backing array
+   *         and requested length.
+   *
+   *  @param elems Constant element backing array.
+   *  @param n     Initial length.
+   * 
+   *  The backing array should be at least as large as the maximum length of the
+   *  vector (see internal::traits information).
+   * 
+   *  Lin assertion errors will be triggered if the requested length isn't
+   *  possible given the vector view's traits.
+   * 
+   *  @sa internal::has_fixed_rows
+   *  @sa internal::has_strictly_bounded_rows
+   */
+  constexpr ConstVectorView(typename Traits::elem_t const *elems, size_t n)
+  : ConstTensorView<ConstVectorView<T, N, MN>>(elems, n, 1) { }
+
+  /** @brief Resizes the constant vector view's length.
+   *  
+   *  @param n Length.
+   * 
+   *  Lin assertion errors will be triggered if the requested length isn't
+   *  possible given the vector view's traits.
+   * 
+   *  @sa internal::has_fixed_rows
+   *  @sa internal::has_strictly_bounded_rows
+   */
+  constexpr void resize(size_t n) {
+    resize(n, 1);
+  }
+};
+
+/** @brief Generic constant row vector view.
+ * 
+ *  @tparam T  Constant row vector view element type.
+ *  @tparam N  Number of elements at compile time (i.e. number of rows).
+ *  @tparam MN Maximum number of elements (i.e. maximum number of rows).
+ * 
+ *  The template parameters specify the row vector views's traits. The traits
+ *  must qualify this type as a row vector.
+ * 
+ *  @sa internal::traits
+ *  @sa internal::is_row_vector
+ * 
+ *  @ingroup VIEWS
+ */
+template <typename T, size_t N, size_t MN = N>
+class ConstRowVectorView : public ConstTensorView<ConstRowVectorView<T, N, MN>> {
+  static_assert(is_row_vector<ConstRowVectorView<T, N, MN>>::value,
+      "Invalid ConstRowVectorView<...> parameters");
+
+ public:
+  /** @brief Traits information for this type.
+   * 
+   *  @sa internal::traits
+   */
+  typedef traits<ConstRowVectorView<T, N, MN>> Traits;
+
+  /** @brief Vector traits information for this type.
+   * 
+   *  @sa internal::vector_traits
+   */
+  typedef vector_traits<ConstRowVectorView<T, N, MN>> VectorTraits;
+
+ protected:
+  using ConstTensorView<ConstRowVectorView<T, N, MN>>::derived;
+
+ public:
+  using ConstTensorView<ConstRowVectorView<T, N, MN>>::ConstTensorView;
+  using ConstTensorView<ConstRowVectorView<T, N, MN>>::rows;
+  using ConstTensorView<ConstRowVectorView<T, N, MN>>::cols;
+  using ConstTensorView<ConstRowVectorView<T, N, MN>>::size;
+  using ConstTensorView<ConstRowVectorView<T, N, MN>>::data;
+  using ConstTensorView<ConstRowVectorView<T, N, MN>>::eval;
+  using ConstTensorView<ConstRowVectorView<T, N, MN>>::resize;
+  using ConstTensorView<ConstRowVectorView<T, N, MN>>::operator=;
+  using ConstTensorView<ConstRowVectorView<T, N, MN>>::operator();
+
+  constexpr ConstRowVectorView() = default;
+  constexpr ConstRowVectorView(ConstRowVectorView<T, N, MN> const &) = default;
+  constexpr ConstRowVectorView(ConstRowVectorView<T, N, MN> &&) = default;
+  constexpr ConstRowVectorView<T, N, MN> &operator=(ConstRowVectorView<T, N, MN> const &) = default;
+  constexpr ConstRowVectorView<T, N, MN> &operator=(ConstRowVectorView<T, N, MN> &&) = default;
+
+  /** @brief Constructs a vector view with the provided backing array and
+   *         requested length.
+   *
+   *  @param elems Constant element backing array.
+   *  @param n     Initial length.
+   * 
+   *  The backing array should be at least as large as the maximum length of the
+   *  row vector (see internal::traits information).
+   * 
+   *  Lin assertion errors will be triggered if the requested length isn't
+   *  possible given the row vector view's traits.
+   * 
+   *  @sa internal::has_fixed_cols
+   *  @sa internal::has_strictly_bounded_cols
+   */
+  constexpr ConstRowVectorView(typename Traits::elem_t const *elems, size_t n)
+  : ConstTensorView<ConstRowVectorView<T, N, MN>>(elems, 1, n) { }
+
+  /** @brief Resizes the row vector view's length.
+   *  
+   *  @param n Length.
+   * 
+   *  Lin assertion errors will be triggered if the requested length isn't
+   *  possible given the row vector view's traits.
+   * 
+   *  @sa internal::has_fixed_cols
+   *  @sa internal::has_strictly_bounded_cols
+   */
+  constexpr void resize(size_t n) {
+    resize(1, n);
+  }
+};
+
+template <typename T, size_t N, size_t MN>
+struct _elem<ConstVectorView<T, N, MN>> {
+  typedef T type;
+};
+
+template <typename T, size_t N, size_t MN>
+struct _dims<ConstVectorView<T, N, MN>> {
+  static constexpr size_t rows = N;
+  static constexpr size_t cols = 1;
+  static constexpr size_t max_rows = MN;
+  static constexpr size_t max_cols = 1;
+};
+
+template <typename T, size_t N, size_t MN>
+struct _elem<ConstRowVectorView<T, N, MN>> {
+  typedef T type;
+};
+
+template <typename T, size_t N, size_t MN>
+struct _dims<ConstRowVectorView<T, N, MN>> {
+  static constexpr size_t rows = 1;
+  static constexpr size_t cols = N;
+  static constexpr size_t max_rows = 1;
+  static constexpr size_t max_cols = MN;
+};
+}  // namespace internal
+}  // namespace lin
+
+#endif

--- a/include/lin/views/matrix_view.hpp
+++ b/include/lin/views/matrix_view.hpp
@@ -15,7 +15,7 @@ namespace internal {
 
 /** @brief Generic matrix view.
  * 
- *  @tparam T  Matrix view element type.
+ *  @tparam T  %Matrix view element type.
  *  @tparam R  Rows at compile time.
  *  @tparam C  Columns at compile time.
  *  @tparam MR Maximum rows at compile time.
@@ -26,6 +26,7 @@ namespace internal {
  * 
  *  @sa internal::traits
  *  @sa internal::is_matrix
+ *  @sa internal::TensorView
  * 
  *  @ingroup VIEWS
  */

--- a/include/lin/views/matrix_view.hpp
+++ b/include/lin/views/matrix_view.hpp
@@ -11,10 +11,11 @@
 #include "tensor_view.hpp"
 
 namespace lin {
+namespace internal {
 
 /** @brief Generic matrix view.
  * 
- *  @param T  %Matrix view element type.
+ *  @tparam T  Matrix view element type.
  *  @tparam R  Rows at compile time.
  *  @tparam C  Columns at compile time.
  *  @tparam MR Maximum rows at compile time.
@@ -29,8 +30,8 @@ namespace lin {
  *  @ingroup VIEWS
  */
 template <typename T, size_t R, size_t C, size_t MR = R, size_t MC = C>
-class MatrixView : public internal::TensorView<MatrixView<T, R, C, MR, MC>> {
-  static_assert(internal::is_matrix<Matrix<T, R, C, MR, MC>>::value,
+class MatrixView : public TensorView<MatrixView<T, R, C, MR, MC>> {
+  static_assert(is_matrix<Matrix<T, R, C, MR, MC>>::value,
       "Invalid MatrixView<...> parameters");
 
  public:
@@ -38,21 +39,21 @@ class MatrixView : public internal::TensorView<MatrixView<T, R, C, MR, MC>> {
    * 
    *  @sa internal::traits
    */
-  typedef internal::traits<MatrixView<T, R, C, MR, MC>> Traits;
+  typedef traits<MatrixView<T, R, C, MR, MC>> Traits;
 
  protected:
-  using internal::TensorView<MatrixView<T, R, C, MR, MC>>::derived;
+  using TensorView<MatrixView<T, R, C, MR, MC>>::derived;
 
  public:
-  using internal::TensorView<MatrixView<T, R, C, MR, MC>>::TensorView;
-  using internal::TensorView<MatrixView<T, R, C, MR, MC>>::rows;
-  using internal::TensorView<MatrixView<T, R, C, MR, MC>>::cols;
-  using internal::TensorView<MatrixView<T, R, C, MR, MC>>::size;
-  using internal::TensorView<MatrixView<T, R, C, MR, MC>>::data;
-  using internal::TensorView<MatrixView<T, R, C, MR, MC>>::eval;
-  using internal::TensorView<MatrixView<T, R, C, MR, MC>>::resize;
-  using internal::TensorView<MatrixView<T, R, C, MR, MC>>::operator=;
-  using internal::TensorView<MatrixView<T, R, C, MR, MC>>::operator();
+  using TensorView<MatrixView<T, R, C, MR, MC>>::TensorView;
+  using TensorView<MatrixView<T, R, C, MR, MC>>::rows;
+  using TensorView<MatrixView<T, R, C, MR, MC>>::cols;
+  using TensorView<MatrixView<T, R, C, MR, MC>>::size;
+  using TensorView<MatrixView<T, R, C, MR, MC>>::data;
+  using TensorView<MatrixView<T, R, C, MR, MC>>::eval;
+  using TensorView<MatrixView<T, R, C, MR, MC>>::resize;
+  using TensorView<MatrixView<T, R, C, MR, MC>>::operator=;
+  using TensorView<MatrixView<T, R, C, MR, MC>>::operator();
 
   constexpr MatrixView() = default;
   constexpr MatrixView(MatrixView<T, R, C, MR, MC> const &) = default;
@@ -60,61 +61,6 @@ class MatrixView : public internal::TensorView<MatrixView<T, R, C, MR, MC>> {
   constexpr MatrixView<T, R, C, MR, MC> &operator=(MatrixView<T, R, C, MR, MC> const &) = default;
   constexpr MatrixView<T, R, C, MR, MC> &operator=(MatrixView<T, R, C, MR, MC> &&) = default;
 };
-
-/** @weakgroup VIEWS
- *  @{
- */
-
-/** @brief Generic float matrix view.
- * 
- *  @tparam R  Rows at compile time.
- *  @tparam C  Columns at compile time.
- *  @tparam MR Maximum rows.
- *  @tparam MC Maximum columns.
- * 
- *  @sa internal::traits
- *  @sa MatrixView
- */
-template <size_t R, size_t C, size_t MR = R, size_t MC = C>
-using MatrixViewf = MatrixView<float, R, C, MR, MC>;
-
-typedef MatrixViewf<2, 2> MatrixView2x2f; ///< Two by two float matrix view.
-typedef MatrixViewf<3, 2> MatrixView3x2f; ///< Three by two float matrix view.
-typedef MatrixViewf<4, 2> MatrixView4x2f; ///< Four by two float matrix view.
-typedef MatrixViewf<2, 3> MatrixView2x3f; ///< Two by three float matrix view.
-typedef MatrixViewf<3, 3> MatrixView3x3f; ///< Three by three float matrix view.
-typedef MatrixViewf<4, 3> MatrixView4x3f; ///< Four by three float matrix view.
-typedef MatrixViewf<2, 4> MatrixView2x4f; ///< Two by four float matrix view.
-typedef MatrixViewf<3, 4> MatrixView3x4f; ///< Three by four float matrix view.
-typedef MatrixViewf<4, 4> MatrixView4x4f; ///< Four by four float matrix view.
-
-/** @brief Generic double matrix view.
- * 
- *  @tparam R  Rows at compile time.
- *  @tparam C  Columns at compile time.
- *  @tparam MR Maximum rows.
- *  @tparam MC Maximum columns.
- * 
- *  @sa internal::traits
- *  @sa MatrixView
- */
-template <size_t R, size_t C, size_t MR = R, size_t MC = C>
-using MatrixViewd = MatrixView<double, R, C, MR, MC>;
-
-typedef MatrixViewd<2, 2> MatrixView2x2d; ///< Two by two double matrix view.
-typedef MatrixViewd<3, 2> MatrixView3x2d; ///< Three by two double matrix view.
-typedef MatrixViewd<4, 2> MatrixView4x2d; ///< Four by two double matrix view.
-typedef MatrixViewd<2, 3> MatrixView2x3d; ///< Two by three double matrix view.
-typedef MatrixViewd<3, 3> MatrixView3x3d; ///< Three by three double matrix view.
-typedef MatrixViewd<4, 3> MatrixView4x3d; ///< Four by three double matrix view.
-typedef MatrixViewd<2, 4> MatrixView2x4d; ///< Two by four double matrix view.
-typedef MatrixViewd<3, 4> MatrixView3x4d; ///< Three by four double matrix view.
-typedef MatrixViewd<4, 4> MatrixView4x4d; ///< Four by four double matrix view.
-
-/** @}
- */
-
-namespace internal {
 
 template <typename T, size_t R, size_t C, size_t MR, size_t MC>
 struct _elem<MatrixView<T, R, C, MR, MC>> {

--- a/include/lin/views/tensor_view.hpp
+++ b/include/lin/views/tensor_view.hpp
@@ -21,9 +21,9 @@ namespace internal {
  *  size and elements are read and written to the buffer in row major order.
  *
  *  @sa internal::Base
- *  @sa MatrixView
- *  @sa RowVectorView
- *  @sa VectorView
+ *  @sa internal::MatrixView
+ *  @sa internal::RowVectorView
+ *  @sa internal::VectorView
  * 
  *  @ingroup VIEWS
  */

--- a/include/lin/views/vector_view.hpp
+++ b/include/lin/views/vector_view.hpp
@@ -11,10 +11,11 @@
 #include "tensor_view.hpp"
 
 namespace lin {
+namespace internal {
 
 /** @brief Generic vector view.
  * 
- *  @tparam T  %Vector view element type.
+ *  @tparam T  Vector view element type.
  *  @tparam N  Number of elements at compile time (i.e. number of rows).
  *  @tparam MN Maximum number of elements (i.e. maximum number of rows).
  * 
@@ -27,8 +28,8 @@ namespace lin {
  *  @ingroup VIEWS
  */
 template <typename T, size_t N, size_t MN = N>
-class VectorView : public internal::TensorView<VectorView<T, N, MN>> {
-  static_assert(internal::is_col_vector<VectorView<T, N, MN>>::value,
+class VectorView : public TensorView<VectorView<T, N, MN>> {
+  static_assert(is_col_vector<VectorView<T, N, MN>>::value,
       "Invalid VectorView<...> parameters");
 
  public:
@@ -36,29 +37,29 @@ class VectorView : public internal::TensorView<VectorView<T, N, MN>> {
    * 
    *  @sa internal::traits
    */
-  typedef internal::traits<VectorView<T, N, MN>> Traits;
+  typedef traits<VectorView<T, N, MN>> Traits;
 
   /** @brief Vector traits information for this type.
    * 
    *  @sa internal::vector_traits
    */
-  typedef internal::vector_traits<VectorView<T, N, MN>> VectorTraits;
+  typedef vector_traits<VectorView<T, N, MN>> VectorTraits;
 
  protected:
-  using internal::TensorView<VectorView<T, N, MN>>::derived;
+  using TensorView<VectorView<T, N, MN>>::derived;
 
  public:
-  using internal::TensorView<VectorView<T, N, MN>>::TensorView;
-  using internal::TensorView<VectorView<T, N, MN>>::rows;
-  using internal::TensorView<VectorView<T, N, MN>>::cols;
-  using internal::TensorView<VectorView<T, N, MN>>::size;
-  using internal::TensorView<VectorView<T, N, MN>>::data;
-  using internal::TensorView<VectorView<T, N, MN>>::eval;
-  using internal::TensorView<VectorView<T, N, MN>>::resize;
-  using internal::TensorView<VectorView<T, N, MN>>::operator=;
-  using internal::TensorView<VectorView<T, N, MN>>::operator();
+  using TensorView<VectorView<T, N, MN>>::TensorView;
+  using TensorView<VectorView<T, N, MN>>::rows;
+  using TensorView<VectorView<T, N, MN>>::cols;
+  using TensorView<VectorView<T, N, MN>>::size;
+  using TensorView<VectorView<T, N, MN>>::data;
+  using TensorView<VectorView<T, N, MN>>::eval;
+  using TensorView<VectorView<T, N, MN>>::resize;
+  using TensorView<VectorView<T, N, MN>>::operator=;
+  using TensorView<VectorView<T, N, MN>>::operator();
 
-  constexpr VectorView() = default;
+  constexpr VectorView() = delete;
   constexpr VectorView(VectorView<T, N, MN> const &) = default;
   constexpr VectorView(VectorView<T, N, MN> &&) = default;
   constexpr VectorView<T, N, MN> &operator=(VectorView<T, N, MN> const &) = default;
@@ -80,7 +81,7 @@ class VectorView : public internal::TensorView<VectorView<T, N, MN>> {
    *  @sa internal::has_strictly_bounded_rows
    */
   constexpr VectorView(typename Traits::elem_t *elems, size_t n)
-  : internal::TensorView<VectorView<T, N, MN>>(elems, n, 1) { }
+  : TensorView<VectorView<T, N, MN>>(elems, n, 1) { }
 
   /** @brief Resizes the vector view's length.
    *  
@@ -99,7 +100,7 @@ class VectorView : public internal::TensorView<VectorView<T, N, MN>> {
 
 /** @brief Generic row vector view.
  * 
- *  @tparam T  Row vector element type.
+ *  @tparam T  Row vector view element type.
  *  @tparam N  Number of elements at compile time (i.e. number of rows).
  *  @tparam MN Maximum number of elements (i.e. maximum number of rows).
  * 
@@ -112,8 +113,8 @@ class VectorView : public internal::TensorView<VectorView<T, N, MN>> {
  *  @ingroup VIEWS
  */
 template <typename T, size_t N, size_t MN = N>
-class RowVectorView : public internal::TensorView<RowVectorView<T, N, MN>> {
-  static_assert(internal::is_row_vector<RowVectorView<T, N, MN>>::value,
+class RowVectorView : public TensorView<RowVectorView<T, N, MN>> {
+  static_assert(is_row_vector<RowVectorView<T, N, MN>>::value,
       "Invalid RowVectorView<...> parameters");
 
  public:
@@ -121,27 +122,27 @@ class RowVectorView : public internal::TensorView<RowVectorView<T, N, MN>> {
    * 
    *  @sa internal::traits
    */
-  typedef internal::traits<RowVectorView<T, N, MN>> Traits;
+  typedef traits<RowVectorView<T, N, MN>> Traits;
 
   /** @brief Vector traits information for this type.
    * 
    *  @sa internal::vector_traits
    */
-  typedef internal::vector_traits<RowVectorView<T, N, MN>> VectorTraits;
+  typedef vector_traits<RowVectorView<T, N, MN>> VectorTraits;
 
  protected:
-  using internal::TensorView<RowVectorView<T, N, MN>>::derived;
+  using TensorView<RowVectorView<T, N, MN>>::derived;
 
  public:
-  using internal::TensorView<RowVectorView<T, N, MN>>::TensorView;
-  using internal::TensorView<RowVectorView<T, N, MN>>::rows;
-  using internal::TensorView<RowVectorView<T, N, MN>>::cols;
-  using internal::TensorView<RowVectorView<T, N, MN>>::size;
-  using internal::TensorView<RowVectorView<T, N, MN>>::data;
-  using internal::TensorView<RowVectorView<T, N, MN>>::eval;
-  using internal::TensorView<RowVectorView<T, N, MN>>::resize;
-  using internal::TensorView<RowVectorView<T, N, MN>>::operator=;
-  using internal::TensorView<RowVectorView<T, N, MN>>::operator();
+  using TensorView<RowVectorView<T, N, MN>>::TensorView;
+  using TensorView<RowVectorView<T, N, MN>>::rows;
+  using TensorView<RowVectorView<T, N, MN>>::cols;
+  using TensorView<RowVectorView<T, N, MN>>::size;
+  using TensorView<RowVectorView<T, N, MN>>::data;
+  using TensorView<RowVectorView<T, N, MN>>::eval;
+  using TensorView<RowVectorView<T, N, MN>>::resize;
+  using TensorView<RowVectorView<T, N, MN>>::operator=;
+  using TensorView<RowVectorView<T, N, MN>>::operator();
 
   constexpr RowVectorView() = default;
   constexpr RowVectorView(RowVectorView<T, N, MN> const &) = default;
@@ -165,7 +166,7 @@ class RowVectorView : public internal::TensorView<RowVectorView<T, N, MN>> {
    *  @sa internal::has_strictly_bounded_cols
    */
   constexpr RowVectorView(typename Traits::elem_t *elems, size_t n)
-  : internal::TensorView<RowVectorView<T, N, MN>>(elems, 1, n) { }
+  : TensorView<RowVectorView<T, N, MN>>(elems, 1, n) { }
 
   /** @brief Resizes the row vector view's length.
    *  
@@ -181,76 +182,6 @@ class RowVectorView : public internal::TensorView<RowVectorView<T, N, MN>> {
     resize(1, n);
   }
 };
-
-/** @weakgroup VIEWS
- *  @{
- */
-
-
-/** @brief Generic float vector view.
- * 
- *  @tparam N  Length at compile time
- *  @tparam MN Max length.
- * 
- *  @sa internal::traits
- *  @sa VectorView
- */
-template <size_t N, size_t MN = N>
-using VectorViewf = VectorView<float, N, MN>;
-
-typedef VectorViewf<2> VectorView2f; ///< Two dimensional float vector view.
-typedef VectorViewf<3> VectorView3f; ///< Three dimensional float vector view.
-typedef VectorViewf<4> VectorView4f; ///< Four dimensional float vector view.
-
-/** @brief Generic double vector view.
- * 
- *  @tparam N  Length at compile time
- *  @tparam MN Max length.
- * 
- *  @sa internal::traits
- *  @sa VectorView
- */
-template <size_t N, size_t MN = N>
-using VectorViewd = VectorView<double, N, MN>;
-
-typedef VectorViewd<2> VectorView2d; ///< Two dimensional double vector view.
-typedef VectorViewd<3> VectorView3d; ///< Three dimensional double vector view.
-typedef VectorViewd<4> VectorView4d; ///< Four dimensional double vector view.
-
-/** @brief Generic float row vector view.
- * 
- *  @tparam N  Length at compile time
- *  @tparam MN Max length.
- * 
- *  @sa internal::traits
- *  @sa RowVectorView
- */
-template <size_t N, size_t MN = N>
-using RowVectorViewf = RowVectorView<float, N, MN>;
-
-typedef RowVectorViewf<2> RowVectorView2f; ///< Two dimensional float row vector view.
-typedef RowVectorViewf<3> RowVectorView3f; ///< Three dimensional float row vector view.
-typedef RowVectorViewf<4> RowVectorView4f; ///< Four dimensional float row vector view.
-
-/** @brief Generic double row vector view.
- * 
- *  @tparam N  Length at compile time
- *  @tparam MN Max length.
- * 
- *  @sa internal::traits
- *  @sa RowVectorView
- */
-template <size_t N, size_t MN = N>
-using RowVectorViewd = RowVectorView<double, N, MN>;
-
-typedef RowVectorViewd<2> RowVectorView2d; ///< Two dimensional double row vector view.
-typedef RowVectorViewd<3> RowVectorView3d; ///< Three dimensional double row vector view.
-typedef RowVectorViewd<4> RowVectorView4d; ///< Four dimensional double row vector view.
-
-/** @}
- */
-
-namespace internal {
 
 template <typename T, size_t N, size_t MN>
 struct _elem<VectorView<T, N, MN>> {

--- a/include/lin/views/vector_view.hpp
+++ b/include/lin/views/vector_view.hpp
@@ -15,7 +15,7 @@ namespace internal {
 
 /** @brief Generic vector view.
  * 
- *  @tparam T  Vector view element type.
+ *  @tparam T  %Vector view element type.
  *  @tparam N  Number of elements at compile time (i.e. number of rows).
  *  @tparam MN Maximum number of elements (i.e. maximum number of rows).
  * 

--- a/include/lin/views/view.hpp
+++ b/include/lin/views/view.hpp
@@ -1,0 +1,180 @@
+// vim: set tabstop=2:softtabstop=2:shiftwidth=2:expandtab
+
+/** @file lin/views/view.hpp
+ *  @author Kyle Krol
+ */
+
+#ifndef LIN_VIEWS_VIEW_HPP_
+#define LIN_VIEWS_VIEW_HPP_
+
+#include "const_matrix_view.hpp"
+#include "const_vector_view.hpp"
+#include "matrix_view.hpp"
+#include "vector_view.hpp"
+
+#include "../core.hpp"
+
+#include <type_traits>
+
+namespace lin {
+
+/** @brief Creates a tensor view with traits based on the provided type.
+ *
+ *  @tparam C Tensor types the view's traits are taken from.
+ *
+ *  @param elems Constant element backing array.
+ *  @param r     Initial row count.
+ *  @param c     Initial column count.
+ *
+ *  @returns Constant matrix view.
+ *
+ *  This overload is chosen if the backing array contains constant elements and
+ *  the traits provided describe a matrix.
+ *
+ *  Lin assertions errors will be triggered if the requested dimensions aren't
+ *  possible given the tensor's traits.
+ *
+ *  @sa internal::traits
+ *  @sa internal::is_matrix
+ *
+ *  @ingroup VIEWS
+ */
+template <class C, std::enable_if_t<internal::conjunction<
+    internal::has_traits<C>, internal::is_matrix<C>>::value, size_t> = 0>
+constexpr auto view(typename C::Traits::elem_t const *elems, size_t r = C::Traits::max_rows, size_t c = C::Traits::max_cols) {
+  return internal::ConstMatrixView<typename C::Traits::elem_t, C::Traits::rows, C::Traits::cols, C::Traits::max_rows, C::Traits::max_cols>(elems, r, c);
+}
+
+/** @brief Creates a tensor view with traits based on the provided type.
+ *
+ *  @tparam C Tensor types the view's traits are taken from.
+ *
+ *  @param elems Constant element backing array.
+ *  @param n     Initial length.
+ *
+ *  @returns Constant vector view.
+ *
+ *  This overload is chosen if the backing array contains constant elements and
+ *  the traits provided describe a column vector.
+ *
+ *  Lin assertions errors will be triggered if the requested dimensions aren't
+ *  possible given the tensor's traits.
+ *
+ *  @sa internal::traits
+ *  @sa internal::is_col_vector
+ *
+ *  @ingroup VIEWS
+ */
+template <class C, std::enable_if_t<internal::conjunction<
+    internal::has_traits<C>, internal::is_col_vector<C>>::value, size_t> = 0>
+constexpr auto view(typename C::Traits::elem_t const *elems, size_t n = C::VectorTraits::max_length) {
+  return internal::ConstVectorView<typename C::VectorTraits::elem_t, C::VectorTraits::length, C::VectorTraits::max_length>(elems, n);
+}
+
+/** @brief Creates a tensor view with traits based on the provided type.
+ *
+ *  @tparam C Tensor types the view's traits are taken from.
+ *
+ *  @param elems Constant element backing array.
+ *  @param n     Initial length.
+ *
+ *  @returns Constant row vector view.
+ *
+ *  This overload is chosen if the backing array contains constant elements and
+ *  the traits provided describe a row vector.
+ *
+ *  Lin assertions errors will be triggered if the requested dimensions aren't
+ *  possible given the tensor's traits.
+ *
+ *  @sa internal::traits
+ *  @sa internal::is_row_vector
+ *
+ *  @ingroup VIEWS
+ */
+template <class C, std::enable_if_t<internal::conjunction<
+    internal::has_traits<C>, internal::is_row_vector<C>>::value, size_t> = 0>
+constexpr auto view(typename C::Traits::elem_t const *elems, size_t n = C::VectorTraits::max_length) {
+  return internal::ConstRowVectorView<typename C::VectorTraits::elem_t, C::VectorTraits::length, C::VectorTraits::max_length>(elems, n);
+}
+
+/** @brief Creates a tensor view with traits based on the provided type.
+ *
+ *  @tparam C Tensor types the view's traits are taken from.
+ *
+ *  @param elems Element backing array.
+ *  @param r     Initial row count.
+ *  @param c     Initial column count.
+ *
+ *  @returns Matrix view.
+ *
+ *  This overload is chosen if the backing array contains writable elements and
+ *  the traits provided describe a matrix.
+ *
+ *  Lin assertions errors will be triggered if the requested dimensions aren't
+ *  possible given the tensor's traits.
+ *
+ *  @sa internal::traits
+ *  @sa internal::is_matrix
+ *
+ *  @ingroup VIEWS
+ */
+template <class C, std::enable_if_t<internal::conjunction<
+    internal::has_traits<C>, internal::is_matrix<C>>::value, size_t> = 0>
+constexpr auto view(typename C::Traits::elem_t *elems, size_t r = C::Traits::max_rows, size_t c = C::Traits::max_cols) {
+  return internal::MatrixView<typename C::Traits::elem_t, C::Traits::rows, C::Traits::cols, C::Traits::max_rows, C::Traits::max_cols>(elems, r, c);
+}
+
+/** @brief Creates a tensor view with traits based on the provided type.
+ *
+ *  @tparam C Tensor types the view's traits are taken from.
+ *
+ *  @param elems Element backing array.
+ *  @param n     Initial length.
+ *
+ *  @returns Vector view.
+ *
+ *  This overload is chosen if the backing array contains writable elements and
+ *  the traits provided describe a column vector.
+ *
+ *  Lin assertions errors will be triggered if the requested dimensions aren't
+ *  possible given the tensor's traits.
+ *
+ *  @sa internal::traits
+ *  @sa internal::is_col_vector
+ *
+ *  @ingroup VIEWS
+ */
+template <class C, std::enable_if_t<internal::conjunction<
+    internal::has_traits<C>, internal::is_col_vector<C>>::value, size_t> = 0>
+constexpr auto view(typename C::Traits::elem_t *elems, size_t n = C::VectorTraits::max_length) {
+  return internal::VectorView<typename C::VectorTraits::elem_t, C::VectorTraits::length, C::VectorTraits::max_length>(elems, n);
+}
+
+/** @brief Creates a tensor view with traits based on the provided type.
+ *
+ *  @tparam C Tensor types the view's traits are taken from.
+ *
+ *  @param elems Element backing array.
+ *  @param n     Initial length.
+ *
+ *  @returns Row vector view.
+ *
+ *  This overload is chosen if the backing array contains writable elements and
+ *  the traits provided describe a row vector.
+ *
+ *  Lin assertions errors will be triggered if the requested dimensions aren't
+ *  possible given the tensor's traits.
+ *
+ *  @sa internal::traits
+ *  @sa internal::is_row_vector
+ *
+ *  @ingroup VIEWS
+ */
+template <class C, std::enable_if_t<internal::conjunction<
+    internal::has_traits<C>, internal::is_row_vector<C>>::value, size_t> = 0>
+constexpr auto view(typename C::Traits::elem_t *elems, size_t n = C::VectorTraits::max_length) {
+  return internal::RowVectorView<typename C::VectorTraits::elem_t, C::VectorTraits::length, C::VectorTraits::max_length>(elems, n);
+}
+}  // namespace lin
+
+#endif

--- a/test/views/matrix_views_test.cpp
+++ b/test/views/matrix_views_test.cpp
@@ -1,9 +1,11 @@
 // vim: set tabstop=2:softtabstop=2:shiftwidth=2:expandtab
 
 #include <lin/core.hpp>
-#include <lin/views/matrix_view.hpp>
+#include <lin/views.hpp>
 
 #include <gtest/gtest.h>
+
+#include <type_traits>
 
 TEST(MatrixViews, FixedSizeMatrixView) {
   float buf[9] = {
@@ -12,8 +14,9 @@ TEST(MatrixViews, FixedSizeMatrixView) {
     7.0f, 8.0f, 9.0f
   };
 
-  lin::MatrixView3x3f A(buf);
-  static_assert(lin::internal::have_same_traits<lin::MatrixView3x3f, lin::Matrix3x3f>::value, "");
+  auto A = lin::view<lin::Matrix3x3f>(buf);
+  static_assert(std::is_same<decltype(A), lin::internal::MatrixView<float, 3, 3>>::value, "");
+  static_assert(lin::internal::have_same_traits<decltype(A), lin::Matrix3x3f>::value, "");
 
   ASSERT_EQ(A.rows(), 3);
   ASSERT_EQ(A.cols(), 3);
@@ -34,6 +37,34 @@ TEST(MatrixViews, FixedSizeMatrixView) {
   ASSERT_EQ(A.data(), buf);
 }
 
+TEST(MatrixViews, FixedSizeConstMatrixView) {
+  float const buf[9] = {
+    1.0f, 2.0f, 3.0f,
+    4.0f, 5.0f, 6.0f,
+    7.0f, 8.0f, 9.0f
+  };
+
+  auto A = lin::view<lin::Matrix3x3f>(buf);
+  static_assert(std::is_same<decltype(A), lin::internal::ConstMatrixView<float, 3, 3>>::value, "");
+  static_assert(lin::internal::have_same_traits<decltype(A), lin::Matrix3x3f>::value, "");
+
+  ASSERT_EQ(A.rows(), 3);
+  ASSERT_EQ(A.cols(), 3);
+
+  ASSERT_FLOAT_EQ(A(0, 0), 1.0f);
+  ASSERT_FLOAT_EQ(A(0, 1), 2.0f);
+  ASSERT_FLOAT_EQ(A(0, 2), 3.0f);
+  ASSERT_FLOAT_EQ(A(1, 0), 4.0f);
+  ASSERT_FLOAT_EQ(A(1, 1), 5.0f);
+  ASSERT_FLOAT_EQ(A(1, 2), 6.0f);
+  ASSERT_FLOAT_EQ(A(2, 0), 7.0f);
+  ASSERT_FLOAT_EQ(A(2, 1), 8.0f);
+  ASSERT_FLOAT_EQ(A(2, 2), 9.0f);
+
+  // Test the correct buffer is returned
+  ASSERT_EQ(A.data(), buf);
+}
+
 TEST(MatrixViews, VariableSizeMatrixView) {
   float buf[9] = {
     1.0f, 2.0f, 3.0f,
@@ -41,8 +72,9 @@ TEST(MatrixViews, VariableSizeMatrixView) {
     7.0f, 8.0f, 9.0f
   };
 
-  lin::MatrixViewf<0, 0, 3, 3> A(buf, 2, 2);
-  static_assert(lin::internal::have_same_traits<lin::Matrixf<0, 0, 3, 3>, lin::MatrixViewf<0, 0, 3, 3>>::value, "");
+  auto A = lin::view<lin::Matrixf<0, 0, 3, 3>>(buf, 2, 2);
+  static_assert(std::is_same<decltype(A), lin::internal::MatrixView<float, 0, 0, 3, 3>>::value, "");
+  static_assert(lin::internal::have_same_traits<decltype(A), lin::Matrixf<0, 0, 3, 3>>::value, "");
 
   ASSERT_EQ(A.rows(), 2);
   ASSERT_EQ(A.cols(), 2);
@@ -62,5 +94,39 @@ TEST(MatrixViews, VariableSizeMatrixView) {
   A(2, 1) = 20.0f;
   ASSERT_FLOAT_EQ(buf[5], 20.0f);
 
+  ASSERT_EQ(A.data(), buf);
+}
+
+TEST(MatrixViews, VariableSizeConstMatrixView) {
+  float const buf[9] = {
+    1.0f, 2.0f, 3.0f,
+    4.0f, 5.0f, 6.0f,
+    7.0f, 8.0f, 9.0f
+  };
+
+  auto A = lin::view<lin::Matrixf<0, 0, 3, 3>>(buf, 2, 2);
+  static_assert(std::is_same<decltype(A), lin::internal::ConstMatrixView<float, 0, 0, 3, 3>>::value, "");
+  static_assert(lin::internal::have_same_traits<decltype(A), lin::Matrixf<0, 0, 3, 3>>::value, "");
+
+  ASSERT_EQ(A.rows(), 2);
+  ASSERT_EQ(A.cols(), 2);
+
+  ASSERT_FLOAT_EQ(A(0, 0), 1.0f);
+  ASSERT_FLOAT_EQ(A(0, 1), 2.0f);
+  ASSERT_FLOAT_EQ(A(1, 0), 3.0f);
+  ASSERT_FLOAT_EQ(A(1, 1), 4.0f);
+
+  A.resize(3, 2);
+  ASSERT_EQ(A.rows(), 3);
+  ASSERT_EQ(A.cols(), 2);
+
+  ASSERT_FLOAT_EQ(A(0, 0), 1.0f);
+  ASSERT_FLOAT_EQ(A(0, 1), 2.0f);
+  ASSERT_FLOAT_EQ(A(1, 0), 3.0f);
+  ASSERT_FLOAT_EQ(A(1, 1), 4.0f);
+  ASSERT_FLOAT_EQ(A(2, 0), 5.0f);
+  ASSERT_FLOAT_EQ(A(2, 1), 6.0f);
+
+  // Test the correct buffer is returned
   ASSERT_EQ(A.data(), buf);
 }

--- a/test/views/vector_views_test.cpp
+++ b/test/views/vector_views_test.cpp
@@ -1,22 +1,20 @@
 // vim: set tabstop=2:softtabstop=2:shiftwidth=2:expandtab
 
 #include <lin/core.hpp>
-#include <lin/views/vector_view.hpp>
+#include <lin/views.hpp>
 
 #include <gtest/gtest.h>
 
+#include <type_traits>
+
 TEST(VectorViews, FixedSizeVectorView) {
-  float buf[3];
+  float buf[3] = {1.0f, 2.0f, 3.0f};
 
-  buf[0] = 1.0f;
-  buf[1] = 2.0f;
-  buf[2] = 3.0f;
-  lin::VectorView3f a(buf);
+  auto a = lin::view<lin::Vector3f>(buf);
+  static_assert(std::is_same<decltype(a), lin::internal::VectorView<float, 3>>::value, "");
+  static_assert(lin::internal::have_same_traits<decltype(a), lin::Vector3f>::value, "");
 
-  // Check traits are correct
-  static_assert(lin::internal::have_same_traits<lin::Vector3f, lin::VectorView3f>::value, "");
-
-  // Check dimesnions
+  // Check dimensions
   ASSERT_EQ(a.rows(), 3);
   ASSERT_EQ(a.cols(), 1);
 
@@ -33,18 +31,34 @@ TEST(VectorViews, FixedSizeVectorView) {
   ASSERT_EQ(a.data(), buf);
 }
 
+TEST(VectorViews, FixedSizeConstVectorView) {
+  float const buf[3] = {1.0f, 2.0f, 3.0f};
+
+  auto a = lin::view<lin::Vector3f>(buf);
+  static_assert(std::is_same<decltype(a), lin::internal::ConstVectorView<float, 3>>::value, "");
+  static_assert(lin::internal::have_same_traits<decltype(a), lin::Vector3f>::value, "");
+
+  // Check dimensions
+  ASSERT_EQ(a.rows(), 3);
+  ASSERT_EQ(a.cols(), 1);
+
+  // Check elements are correct
+  ASSERT_FLOAT_EQ(a(0), 1.0f);
+  ASSERT_FLOAT_EQ(a(1), 2.0f);
+  ASSERT_FLOAT_EQ(a(2), 3.0f);
+
+  // Test the correct buffer is returned
+  ASSERT_EQ(a.data(), buf);
+}
+
 TEST(VectorViews, FixedSizeRowVectorView) {
-  float buf[3];
+  float buf[3] = {1.0f, 2.0f, 3.0f};
 
-  buf[0] = 1.0f;
-  buf[1] = 2.0f;
-  buf[2] = 3.0f;
-  lin::RowVectorView3f a(buf);
+  auto a = lin::view<lin::RowVector3f>(buf);
+  static_assert(std::is_same<decltype(a), lin::internal::RowVectorView<float, 3>>::value, "");
+  static_assert(lin::internal::have_same_traits<decltype(a), lin::RowVector3f>::value, "");
 
-  // Check traits are correct
-  static_assert(lin::internal::have_same_traits<lin::RowVector3f, lin::RowVectorView3f>::value, "");
-
-  // Check dimesnions
+  // Check dimensions
   ASSERT_EQ(a.rows(), 1);
   ASSERT_EQ(a.cols(), 3);
 
@@ -56,21 +70,39 @@ TEST(VectorViews, FixedSizeRowVectorView) {
   // Test changes are reflected in the original buffer
   a(1) = 4.0f;
   ASSERT_FLOAT_EQ(buf[1], 4.0f);
+
+  // Test the correct buffer is returned
+  ASSERT_EQ(a.data(), buf);
+}
+
+TEST(VectorViews, FixedSizeConstRowVectorView) {
+  float const buf[3] = {1.0f, 2.0f, 3.0f};
+
+  auto a = lin::view<lin::RowVector3f>(buf);
+  static_assert(std::is_same<decltype(a), lin::internal::ConstRowVectorView<float, 3>>::value, "");
+  static_assert(lin::internal::have_same_traits<decltype(a), lin::RowVector3f>::value, "");
+
+  // Check dimensions
+  ASSERT_EQ(a.rows(), 1);
+  ASSERT_EQ(a.cols(), 3);
+
+  // Check elements are correct
+  ASSERT_FLOAT_EQ(a(0), 1.0f);
+  ASSERT_FLOAT_EQ(a(1), 2.0f);
+  ASSERT_FLOAT_EQ(a(2), 3.0f);
+
+  // Test the correct buffer is returned
+  ASSERT_EQ(a.data(), buf);
 }
 
 TEST(VectorViews, VariableSizeVectorView) {
-  double buf[6];
+  double buf[6] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
 
-  buf[0] = 1.0;
-  buf[1] = 2.0;
-  buf[2] = 3.0;
-  buf[3] = 4.0;
-  lin::VectorViewd<0, 6> a(buf, 4);
+  auto a = lin::view<lin::Vectord<0, 6>>(buf, 4);
+  static_assert(std::is_same<decltype(a), lin::internal::VectorView<double, 0, 6>>::value, "");
+  static_assert(lin::internal::have_same_traits<decltype(a), lin::Vectord<0, 6>>::value, "");
 
-  // Check traits are correct
-  static_assert(lin::internal::have_same_traits<lin::Vectord<0, 6>, lin::VectorViewd<0, 6>>::value, "");
-
-  // Check dimesnions
+  // Check dimensions
   ASSERT_EQ(a.rows(), 4);
   ASSERT_EQ(a.cols(), 1);
 
@@ -94,17 +126,40 @@ TEST(VectorViews, VariableSizeVectorView) {
   ASSERT_EQ(a.data(), buf);
 }
 
+TEST(VectorViews, VariableSizeConstVectorView) {
+  double const buf[6] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+
+  auto a = lin::view<lin::Vectord<0, 6>>(buf, 4);
+  static_assert(std::is_same<decltype(a), lin::internal::ConstVectorView<double, 0, 6>>::value, "");
+  static_assert(lin::internal::have_same_traits<decltype(a), lin::Vectord<0, 6>>::value, "");
+
+  // Check dimensions
+  ASSERT_EQ(a.rows(), 4);
+  ASSERT_EQ(a.cols(), 1);
+
+  // Check elements are correct
+  ASSERT_DOUBLE_EQ(a(0), 1.0);
+  ASSERT_DOUBLE_EQ(a(1), 2.0);
+  ASSERT_DOUBLE_EQ(a(2), 3.0);
+  ASSERT_DOUBLE_EQ(a(3), 4.0);
+
+  // Test resize
+  a.resize(6);
+  ASSERT_EQ(a.rows(), 6);
+  ASSERT_DOUBLE_EQ(buf[5], 6.0);
+
+  // Test the correct buffer is returned
+  ASSERT_EQ(a.data(), buf);
+}
+
 TEST(VectorViews, VariableSizeRowVectorView) {
-  double buf[6];
+  double buf[6] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
 
-  buf[0] = 1.0;
-  buf[1] = 2.0;
-  lin::RowVectorViewd<0, 6> a(buf, 2);
+  auto a = lin::view<lin::RowVectord<0, 6>>(buf, 2);
+  static_assert(std::is_same<decltype(a), lin::internal::RowVectorView<double, 0, 6>>::value, "");
+  static_assert(lin::internal::have_same_traits<decltype(a), lin::RowVectord<0, 6>>::value, "");
 
-  // Check traits are correct
-  static_assert(lin::internal::have_same_traits<lin::RowVectord<0, 6>, lin::RowVectorViewd<0, 6>>::value, "");
-
-  // Check dimesnions
+  // Check dimensions
   ASSERT_EQ(a.rows(), 1);
   ASSERT_EQ(a.cols(), 2);
 
@@ -121,6 +176,30 @@ TEST(VectorViews, VariableSizeRowVectorView) {
   a(4) = 10.0;
   ASSERT_EQ(a.cols(), 5);
   ASSERT_DOUBLE_EQ(buf[4], 10.0);
+
+  // Test the correct buffer is returned
+  ASSERT_EQ(a.data(), buf);
+}
+
+TEST(VectorViews, VariableSizeConstRowVectorView) {
+  double const buf[6] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+
+  auto a = lin::view<lin::RowVectord<0, 6>>(buf, 2);
+  static_assert(std::is_same<decltype(a), lin::internal::ConstRowVectorView<double, 0, 6>>::value, "");
+  static_assert(lin::internal::have_same_traits<decltype(a), lin::RowVectord<0, 6>>::value, "");
+
+  // Check dimensions
+  ASSERT_EQ(a.rows(), 1);
+  ASSERT_EQ(a.cols(), 2);
+
+  // Check elements are correct
+  ASSERT_DOUBLE_EQ(a(0), 1.0);
+  ASSERT_DOUBLE_EQ(a(1), 2.0);
+
+  // Test resize
+  a.resize(5);
+  ASSERT_EQ(a.cols(), 5);
+  ASSERT_DOUBLE_EQ(buf[4], 5.0);
 
   // Test the correct buffer is returned
   ASSERT_EQ(a.data(), buf);


### PR DESCRIPTION
### Summary of Changes

* Added the idea of `const` views to allow `const` buffers to be treated as read only lin objects.
* Move all "views" objects to the internal namespace in favor of allowing overloads of the new `lin::views` function to determine the appropriate return type at compile time.
* Updated unit tests appropriately.
* Updated doxygen documentation.
* Update .gitignore to contain `compile_commands.json` for C++ Intellisense.

### Feature Description

In short, views are now all constructed through the `lin::view` function. The returned view will be constant if the provided buffer was `const` and will have traits equivalent to the provided type. An example usage was included in the updated doxygen documentation but a short one is provided below as well:

```
#include <lin/core.hpp>
#include <lin/views.hpp>

#include <array>

template <typename T, std::size_t N>
constexpr void twice(std::array<T, N> &a) {
  auto v = lin::view<lin::Vector<T, N>>(a.data());
  v = T(2) * v;
}
```

Once merged, better documentation will also be available here: https://pathfinder-for-autonomous-navigation.github.io/lin/group___v_i_e_w_s.html