### PR TITLE
Update CI to Include GH Pages Deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,20 @@ matrix:
         - pip install -vvv .
       script:
         - pytest -v test_lin.py
+    - sudo: false
+      branches:
+          only:
+              - master
+      addons:
+          apt:
+              packages:
+                  - doxygen
+      script:
+          - cd docs && doxygen && cd ..
+      deploy:
+          provider: pages
+          skip_cleanup: true
+          local_dir: docs/html
+          github_token: $GH_REPO_TOKEN
+          on:
+              branch: master


### PR DESCRIPTION
Somehow this got lost in the shuffle and the automatic documentation deployment currently isn't working.