### PR TITLE
Diagonal Generators and References

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -856,9 +856,11 @@ INPUT                  = \
   ../include/lin/references/tensor_mapping_reference.hpp \
   ../include/lin/references/matrix_mapping_reference.hpp \
   ../include/lin/references/vector_mapping_reference.hpp \
+  ../include/lin/references/diagonal_mapping_reference.hpp \
   ../include/lin/references/tensor_stream_reference.hpp \
   ../include/lin/references/matrix_stream_reference.hpp \
   ../include/lin/references/vector_stream_reference.hpp \
+  ../include/lin/references/diagonal_stream_reference.hpp \
   ../include
 
 # This tag can be used to specify the character encoding of the source files

--- a/include/lin/factorizations/inl/qr.inl
+++ b/include/lin/factorizations/inl/qr.inl
@@ -19,7 +19,7 @@ constexpr int qr(internal::Stream<C> const &M, internal::Mapping<D> &Q, internal
   Q = M;
 
   for (size_t j = 0; j < M.cols(); j++) {
-    auto qj = ref_col(Q, j);
+    auto qj = col(Q, j);
 
     // Normalize this column
     R(j, j) = norm(qj);
@@ -27,7 +27,7 @@ constexpr int qr(internal::Stream<C> const &M, internal::Mapping<D> &Q, internal
 
     // Remove parallel components from subsequent columns
     for (size_t k = j + 1; k < M.cols(); k++) {
-      auto qk = ref_col(Q, k);
+      auto qk = col(Q, k);
       R(j, k) = dot(qj, qk);
       qk = qk - qj * R(j, k);
     }

--- a/include/lin/generators.hpp
+++ b/include/lin/generators.hpp
@@ -16,6 +16,7 @@
 #define LIN_GENERATORS_HPP_
 
 #include "generators/constants.hpp"
+#include "generators/diagonal.hpp"
 #include "generators/identity.hpp"
 #include "generators/randoms.hpp"
 #include "generators/stream_constants.hpp"

--- a/include/lin/generators/diagonal.hpp
+++ b/include/lin/generators/diagonal.hpp
@@ -1,0 +1,34 @@
+// vim: set tabstop=2:softtabstop=2:shiftwidth=2:expandtab
+
+/** @file lin/generators/diagonal.hpp
+ *  @author Kyle Krol
+ */
+
+#ifndef LIN_GENERATORS_DIAGONAL_HPP_
+#define LIN_GENERATORS_DIAGONAL_HPP_
+
+#include "stream_diagonal.hpp"
+#include "../core.hpp"
+
+#include <limits>
+#include <type_traits>
+
+namespace lin {
+
+/** @brief Creates a diagonal stream from a vector stream.
+ *
+ *  @tparam D Underlying type.
+ *
+ *  @param stream Underlying vector stream.
+ *
+ *  @return Instance of an internal::StreamDiagonal
+ *
+ *  @sa internal::is_vector
+ */
+template <class D, typename std::enable_if_t<internal::is_vector<D>::value, size_t> = 0>
+constexpr auto diag(internal::Stream<D> const &stream) {
+  return internal::StreamDiagonal<D>(stream);
+}
+}  // namespace lin
+
+#endif

--- a/include/lin/generators/stream_diagonal.hpp
+++ b/include/lin/generators/stream_diagonal.hpp
@@ -1,0 +1,149 @@
+// vim: set tabstop=2:softtabstop=2:shiftwidth=2:expandtab
+
+/** @file lin/generators/stream_diagonal.hpp
+ *  @author Kyle Krol
+ */
+
+#ifndef LIN_GENERATORS_STREAM_DIAGONAL_HPP_
+#define LIN_GENERATORS_STREAM_DIAGONAL_HPP_
+
+#include "../core.hpp"
+
+namespace lin {
+namespace internal {
+
+/** @brief Tensor stream where all elements are zeros expects the elements on
+ *         on the diagonal specified by an underlying stream.
+ *
+ *  @tparam E Underlying vector stream.
+ *
+ *  This allows a user to sparesly define a square matrix stream where all
+ *  elements evaluate to zero except for the those along the diagonal, which are
+ *  specified by the elements of an underlying vector.
+ *
+ *  Note the if the underlying vector goes out of scope the diagonal stream is
+ *  invalidated.
+ *
+ *  @sa internal::is_matrix
+ *  @sa internal::is_square
+ *
+ *  @ingroup GENERATORS
+ */
+template <class E>
+class StreamDiagonal : public Stream<StreamDiagonal<E>> {
+  static_assert(conjunction<is_matrix<StreamDiagonal<E>>, is_square<StreamDiagonal<E>>>::value,
+      "StreamDiagonal must have square, matrix traits");
+  static_assert(is_vector<E>::value,
+      "Backing type for a StreamDiagonal must have vector traits");
+
+ public:
+  /** @brief Traits information for this type.
+   * 
+   *  @sa internal::traits
+   */
+  typedef traits<StreamDiagonal<E>> Traits;
+
+ private:
+  Stream<E> const &_stream;
+
+ protected:
+  using Stream<StreamDiagonal<E>>::derived;
+
+ public:
+  using Stream<StreamDiagonal<E>>::size;
+  using Stream<StreamDiagonal<E>>::eval;
+
+  constexpr StreamDiagonal() = delete;
+  constexpr StreamDiagonal(StreamDiagonal<E> const &) = default;
+  constexpr StreamDiagonal(StreamDiagonal<E> &&) = default;
+  constexpr StreamDiagonal<E> &operator=(StreamDiagonal<E> const &) = default;
+  constexpr StreamDiagonal<E> &operator=(StreamDiagonal<E> &&) = default;
+
+  /** @brief Constructs a new diagonal stream from the provided vector stream.
+   *
+   *  @param stream Underlying vector stream
+   *
+   *  The provided vector streams length will determine the runtime dimensions
+   *  of the diagonal stream.
+   *
+   *  Changes in element values and dimensions of the underlying vector stream
+   *  will be reflected in the stream itself. The underlying stream must be in
+   *  scope for the stream to be valid.
+   */
+  constexpr StreamDiagonal(Stream<E> const &stream)
+  : _stream(stream) { }
+
+  /** @return Number of rows.
+   *
+   *  Equals the size of the underlying vector.
+   */
+  constexpr size_t rows() const {
+    return _stream.size();
+  }
+
+  /** @return Number of rows.
+   *
+   *  Equals the size of the underlying vector.
+   */
+  constexpr size_t cols() const {
+    return _stream.size();
+  }
+
+  /** @brief Provides read only access to tensor elements.
+   *
+   *  @param i Row index.
+   *  @param j Column index.
+   *
+   *  @return Value of the tensor element.
+   *
+   *  Zero if off the main diagonal and specified by the underlying vector
+   *  stream otherwise.
+   * 
+   *  If the indices are out of bounds as defined by the stream's current
+   *  dimensions, lin assertion errors will be triggered.
+   */
+  constexpr typename Traits::elem_t operator()(size_t i, size_t j) const {
+    LIN_ASSERT(0 <= i && i <= rows());
+    LIN_ASSERT(0 <= j && j <= cols());
+
+    return i == j ? _stream(i) : typename Traits::elem_t(0);
+  }
+
+  /** @brief Provides read only access to tensor elements.
+   *
+   *  @param i Index.
+   *
+   *  @return Value of the tensor element.
+   *
+   *  Element access proceeds as if all the elements of the tensor stream were
+   *  flattened into an array in row major order.
+   *
+   *  Zero if off the main diagonal and specified by the underlying vector
+   *  stream otherwise.
+   *
+   *  If the index is out of bounds as defined by the stream's current size, lin
+   *  assertion errors will be triggered.
+   */
+  constexpr typename Traits::elem_t operator()(size_t i) const {
+    LIN_ASSERT(0 <= i && i <= size());
+
+    return (*this)(i / cols(), i % cols());
+  }
+};
+
+template <class E>
+struct _elem<StreamDiagonal<E>> {
+  typedef _elem_t<E> type;
+};
+
+template <class E>
+struct _dims<StreamDiagonal<E>> {
+  static constexpr size_t rows = _vector_dims<E>::length;
+  static constexpr size_t cols = _vector_dims<E>::length;
+  static constexpr size_t max_rows = _vector_dims<E>::max_length;
+  static constexpr size_t max_cols = _vector_dims<E>::max_length;
+};
+}  // namespace internal
+}  // namespace lin
+
+#endif

--- a/include/lin/references/diagonal_mapping_reference.hpp
+++ b/include/lin/references/diagonal_mapping_reference.hpp
@@ -1,0 +1,153 @@
+// vim: set tabstop=2:softtabstop=2:shiftwidth=2:expandtab
+
+/** @file lin/references/diagonal_mapping_reference.hpp
+ *  @author Kyle Krol
+ */
+
+#ifndef LIN_REFERENCES_DIAGONAL_MAPPING_REFERENCE_HPP_
+#define LIN_REFERENCES_DIAGONAL_MAPPING_REFERENCE_HPP_
+
+#include "../core.hpp"
+
+namespace lin {
+namespace internal {
+
+/** @brief Generic diagonal reference with read and write access.
+ *
+ *  @tparam E Underlying referenced type.
+ *
+ *  This allows users to treat the diagonal elements of a mapping as a column
+ *  vector. The underlying mapping must have traits making is a square matrix.
+ *
+ *  It's important to note, if the underlying mapping goes out of scope the
+ *  reference is invalidated.
+ *
+ *  @sa internal::DiagonalMappingReference
+ *  @sa internal::is_matrix
+ *  @sa internal::is_square
+ */
+template <class E>
+class DiagonalMappingReference : public Mapping<DiagonalMappingReference<E>> {
+  static_assert(is_vector<DiagonalMappingReference<E>>::value,
+      "DiagonalMappingReference<...> types must have vector traits.");
+  static_assert(conjunction<is_matrix<E>, is_square<E>>::value,
+      "Underlying mapping for a diagonal reference must be a square matrix.");
+
+ public:
+  /** @brief Traits information for this type.
+   *
+   *  @sa internal::traits
+   */
+  typedef traits<DiagonalMappingReference<E>> Traits;
+
+  /** @brief %Vector traits information for this type.
+   *
+   *  @sa internal::vector_traits
+   */
+  typedef vector_traits<DiagonalMappingReference<E>> VectorTraits;
+
+ private:
+  Mapping<E> &_mapping;
+
+ protected:
+  using Mapping<DiagonalMappingReference<E>>::derived;
+
+ public:
+  using Mapping<DiagonalMappingReference<E>>::size;
+  using Mapping<DiagonalMappingReference<E>>::eval;
+  using Mapping<DiagonalMappingReference<E>>::operator();
+  using Mapping<DiagonalMappingReference<E>>::operator=;
+
+  constexpr DiagonalMappingReference() = delete;
+  constexpr DiagonalMappingReference(DiagonalMappingReference<E> const &) = default;
+  constexpr DiagonalMappingReference(DiagonalMappingReference<E> &&) = default;
+  constexpr DiagonalMappingReference<E> &operator=(DiagonalMappingReference<E> const &) = default;
+  constexpr DiagonalMappingReference<E> &operator=(DiagonalMappingReference<E> &&) = default;
+
+  /** @brief Constructs a new diagonal reference with the provided mapping.
+   *
+   *  @param mapping Underlying mapping.
+   *
+   *  The provided mapping must be square at runtime or lin assertion errors
+   *  will be triggered.
+   *
+   *  Resizing the mapping to be something other than square after construction
+   *  invalidates the reference.
+   */
+  constexpr DiagonalMappingReference(Mapping<E> &mapping)
+  : _mapping(mapping) {
+    LIN_ASSERT(mapping.rows() == mapping.cols());
+  }
+
+  /** @return Number of rows.
+   *
+   *  This value is determined based on the size of the underlying mapping. If
+   *  the mapping is resized, the returned row count may changed. If the resized
+   *  mapping is no longer square, the diagonal reference is invalidated.
+   */
+  constexpr size_t rows() const {
+    return _mapping.rows();
+  }
+
+  /** @return Number of columns.
+   *
+   *  This always returns one.
+   */
+  constexpr size_t cols() const {
+    return size_t(1);
+  }
+
+  /** @brief Provides read and write access to tensor elements.
+   *
+   *  @param i Row index.
+   *  @param j Column index.
+   *
+   *  @return Reference to the tensor element.
+   *
+   *  The diagonal of the underlying stream is exposed as a column vector.
+   *
+   *  If the indices are out of bounds as defined by the reference's current
+   *  dimensions, lin assertion errors will be triggered.
+   */
+  constexpr typename Traits::elem_t &operator()(size_t i, size_t j) {
+    LIN_ASSERT(i >= 0 && i < rows());
+    LIN_ASSERT(j >= 0 && j < rows());
+
+    return _mapping(i, i);
+  }
+
+  /** @brief Provides read and write access to tensor elements.
+   *
+   *  @param i Index.
+   *
+   *  @return Reference to the tensor element.
+   *
+   *  Element access proceeds as if all the elements of the tensor stream were
+   *  flattened into an array in row major order.
+   *
+   *  If the index is out of bounds as defined by the reference's current size,
+   *  lin assertion errors will be triggered.
+   */
+  constexpr typename Traits::elem_t &operator()(size_t i) {
+    LIN_ASSERT(i >= 0 && i < size());
+
+    return _mapping(i, i);
+  }
+};
+
+template <class E>
+struct _elem<DiagonalMappingReference<E>> {
+  typedef _elem_t<E> type;
+};
+
+template <class E>
+struct _dims<DiagonalMappingReference<E>> {
+  constexpr static size_t rows = E::Traits::rows;
+  constexpr static size_t cols = 1;
+  constexpr static size_t max_rows = E::Traits::max_rows;
+  constexpr static size_t max_cols = 1;
+};
+}  // namespace internal
+}  // namespace lin
+
+#endif

--- a/include/lin/references/diagonal_stream_reference.hpp
+++ b/include/lin/references/diagonal_stream_reference.hpp
@@ -1,0 +1,151 @@
+// vim: set tabstop=2:softtabstop=2:shiftwidth=2:expandtab
+
+/** @file lin/references/diagonal_stream_reference.hpp
+ *  @author Kyle Krol
+ */
+
+#ifndef LIN_REFERENCES_DIAGONAL_STREAM_REFERENCE_HPP_
+#define LIN_REFERENCES_DIAGONAL_STREAM_REFERENCE_HPP_
+
+#include "../core.hpp"
+
+namespace lin {
+namespace internal {
+
+/** @brief Generic diagonal reference with read only access.
+ *
+ *  @tparam E Underlying referenced type.
+ *
+ *  This allows users to treat the diagonal elements of a stream as a column
+ *  vector. The underlying stream must have traits making is a square matrix.
+ *
+ *  It's important to note, if the underlying stream goes out of scope the
+ *  reference is invalidated.
+ *
+ *  @sa internal::DiagonalMappingReference
+ *  @sa internal::is_matrix
+ *  @sa internal::is_square
+ */
+template <class E>
+class DiagonalStreamReference : public Stream<DiagonalStreamReference<E>> {
+  static_assert(is_vector<DiagonalStreamReference<E>>::value,
+      "DiagonalStreamReference<...> types must have vector traits.");
+  static_assert(conjunction<is_matrix<E>, is_square<E>>::value,
+      "Underlying mapping for a diagonal reference must be a square matrix.");
+
+ public:
+  /** @brief Traits information for this type.
+   *
+   *  @sa internal::traits
+   */
+  typedef traits<DiagonalStreamReference<E>> Traits;
+
+  /** @brief %Vector traits information for this type.
+   *
+   *  @sa internal::vector_traits
+   */
+  typedef vector_traits<DiagonalStreamReference<E>> VectorTraits;
+
+ private:
+  Stream<E> const &_stream;
+
+ protected:
+  using Stream<DiagonalStreamReference<E>>::derived;
+
+ public:
+  using Stream<DiagonalStreamReference<E>>::size;
+  using Stream<DiagonalStreamReference<E>>::eval;
+
+  constexpr DiagonalStreamReference() = delete;
+  constexpr DiagonalStreamReference(DiagonalStreamReference<E> const &) = default;
+  constexpr DiagonalStreamReference(DiagonalStreamReference<E> &&) = default;
+  constexpr DiagonalStreamReference<E> &operator=(DiagonalStreamReference<E> const &) = default;
+  constexpr DiagonalStreamReference<E> &operator=(DiagonalStreamReference<E> &&) = default;
+
+  /** @brief Constructs a new diagonal reference with the provided stream.
+   *
+   *  @param stream Underlying stream.
+   *
+   *  The provided stream must be square at runtime or lin assertion errors will
+   *  be triggered.
+   *
+   *  Resizing the stream to be something other than square after construction
+   *  invalidates the reference.
+   */
+  constexpr DiagonalStreamReference(Stream<E> const &stream)
+  : _stream(stream) {
+    LIN_ASSERT(stream.rows() == stream.cols());
+  }
+
+  /** @return Number of rows.
+   *
+   *  This value is determined based on the size of the underlying stream. If
+   *  the stream is resized, the returned row count may changed. If the resized
+   *  stream is no longer square, the diagonal reference is invalidated.
+   */
+  constexpr size_t rows() const {
+    return _stream.rows();
+  }
+
+  /** @return Number of columns.
+   *
+   *  This always returns one.
+   */
+  constexpr size_t cols() const {
+    return size_t(1);
+  }
+
+  /** @brief Provides read only access to tensor elements.
+   *
+   *  @param i Row index.
+   *  @param j Column index.
+   *
+   *  @return Value of the tensor element.
+   *
+   *  The diagonal of the underlying stream is exposed as a column vector.
+   *
+   *  If the indices are out of bounds as defined by the reference's current
+   *  dimensions, lin assertion errors will be triggered.
+   */
+  constexpr typename Traits::elem_t operator()(size_t i, size_t j) const {
+    LIN_ASSERT(i >= 0 && i < rows());
+    LIN_ASSERT(j >= 0 && j < cols());
+
+    return _stream(i, i);
+  }
+
+  /** @brief Provides read only access to tensor elements.
+   *
+   *  @param i Index.
+   *
+   *  @return Value of the tensor element.
+   *
+   *  Element access proceeds as if all the elements of the tensor stream were
+   *  flattened into an array in row major order.
+   *
+   *  If the index is out of bounds as defined by the reference's current size,
+   *  lin assertion errors will be triggered.
+   */
+  constexpr typename Traits::elem_t operator()(size_t i) const {
+    LIN_ASSERT(i >= 0 && i < size());
+
+    return _stream(i, i);
+  }
+};
+
+template <class E>
+struct _elem<DiagonalStreamReference<E>> {
+  typedef _elem_t<E> type;
+};
+
+template <class E>
+struct _dims<DiagonalStreamReference<E>> {
+  constexpr static size_t rows = E::Traits::rows;
+  constexpr static size_t cols = 1;
+  constexpr static size_t max_rows = E::Traits::max_rows;
+  constexpr static size_t max_cols = 1;
+};
+}  // namespace internal
+}  // namespace lin
+
+#endif

--- a/include/lin/substitutions/inl/backward_substitution.inl
+++ b/include/lin/substitutions/inl/backward_substitution.inl
@@ -22,12 +22,12 @@ constexpr int backward_sub(internal::Mapping<C> const &U, internal::Mapping<D> &
   // Solve for the last rows
   // It's trivially the last row of Y divided by the bottom right element of U
   const size_t m = U.rows() - 1;
-  ref_row(X, m) = ref_row(Y, m) / U(m, m);
+  row(X, m) = row(Y, m) / U(m, m);
 
   // Solve for the other rows in descending order
   for (size_t n = m - 1;; n--) {
-    ref_row(X, n) = (
-            ref_row(Y, n) - (ref<RowVector<typename TU::elem_t, 0, TU::max_rows>>(U, n, n + 1, m - n) *
+    row(X, n) = (
+            row(Y, n) - (ref<RowVector<typename TU::elem_t, 0, TU::max_rows>>(U, n, n + 1, m - n) *
                 ref<Matrix<typename TU::elem_t, 0, TY::cols, TY::max_rows,TY::max_cols>>(X, n + 1, 0, m - n, X.cols()))
         ) / U(n, n);
     if (n == 0) break;  // Must perform this check here for unsigned valu

--- a/include/lin/substitutions/inl/forward_substitution.inl
+++ b/include/lin/substitutions/inl/forward_substitution.inl
@@ -24,12 +24,12 @@ constexpr int forward_sub(internal::Mapping<C> const &L, internal::Mapping<D> &X
   constexpr size_t E_max_cols = E::Traits::max_cols;
 
   // X(0, :)
-  ref_row(X, 0) = ref_row(Y, 0) / L(0, 0);
+  row(X, 0) = row(Y, 0) / L(0, 0);
 
   // X(1:, :)
   for (size_t i = 1; i < X.rows(); i++)
     // X(i, :)
-    ref_row(X, i) = ( ref_row(Y, i) - ref<RowVector<Elem, 0, C_max_cols>>(L, i, 0, i) *
+    row(X, i) = ( row(Y, i) - ref<RowVector<Elem, 0, C_max_cols>>(L, i, 0, i) *
         ref<Matrix<Elem, 0, E_cols, E_max_rows, E_max_cols>>(X, 0, 0, i, X.cols())
       ) / L(i, i);
 

--- a/test/generators/diagonal_test.cpp
+++ b/test/generators/diagonal_test.cpp
@@ -1,0 +1,40 @@
+/** @file test/generators/diagonal_test.cpp
+ *  @author Kyle Krol */
+
+#include <lin/core.hpp>
+#include <lin/generators/diagonal.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <type_traits>
+
+TEST(GeneratorsDiagonal, Diagonal) {
+  lin::Vector2f a = {
+    1.0f,
+    2.0f
+  };
+
+  auto const A = lin::diag(a);
+  static_assert(lin::internal::have_same_traits<std::remove_const_t<decltype(A)>, lin::Matrix2x2f>::value, "");
+  ASSERT_FLOAT_EQ(1.0f, A(0, 0));
+  ASSERT_FLOAT_EQ(0.0f, A(0, 1));
+  ASSERT_FLOAT_EQ(0.0f, A(1, 0));
+  ASSERT_FLOAT_EQ(2.0f, A(1, 1));
+  ASSERT_EQ(2, A.rows());
+  ASSERT_EQ(2, A.cols());
+
+  lin::Vectorf<0, 3> b(2, {
+    1.0f,
+    2.0f
+  });
+
+  auto const B = lin::diag(b);
+  static_assert(lin::internal::have_same_traits<std::remove_const_t<decltype(B)>, lin::Matrixf<0, 0, 3, 3>>::value, "");
+  ASSERT_FLOAT_EQ(1.0f, B(0, 0));
+  ASSERT_FLOAT_EQ(0.0f, B(0, 1));
+  ASSERT_FLOAT_EQ(0.0f, B(1, 0));
+  ASSERT_FLOAT_EQ(2.0f, B(1, 1));
+  ASSERT_EQ(2, B.rows());
+  ASSERT_EQ(2, B.cols());
+}

--- a/test/references/mapping_reference_test.cpp
+++ b/test/references/mapping_reference_test.cpp
@@ -111,3 +111,40 @@ TEST(MappingReference, RowVectorMappingReference) {
   d(1) = 10.0f;
   ASSERT_FLOAT_EQ(10.0f, A(2, 2));
 }
+
+TEST(MappingReference, DiagonalMappingReference) {
+  lin::Matrix3x3f A = {
+    0.0f, 1.0f, 2.0f,
+    3.0f, 4.0f, 5.0f,
+    6.0f, 7.0f, 8.0f
+  };
+  lin::Vector3f a = {
+    0.0f,
+    4.0f,
+    8.0f
+  };
+
+  auto b = lin::diag(A);
+  static_assert(lin::internal::have_same_traits<decltype(b), lin::Vector3f>::value, "");
+  ASSERT_FLOAT_EQ(0.0f, lin::fro(a - b));
+  ASSERT_EQ(3, b.rows());
+  ASSERT_EQ(1, b.cols());
+
+  lin::Matrixf<0, 0, 5, 5> B(2, 2, {
+    0.0f, 1.0f,
+    2.0f, 3.0f
+  });
+  lin::Vectorf<0, 5> c(2, {
+    0.0f,
+    3.0f
+  });
+
+  auto d = lin::diag(B);
+  static_assert(lin::internal::have_same_traits<decltype(d), lin::Vectorf<0, 5>>::value, "");
+  ASSERT_FLOAT_EQ(0.0f, lin::fro(c - d));
+  ASSERT_EQ(2, d.rows());
+  ASSERT_EQ(1, d.cols());
+
+  d(1) = 4.0f;
+  ASSERT_FLOAT_EQ(4.0f, B(1, 1));
+}

--- a/test/references/stream_reference_test.cpp
+++ b/test/references/stream_reference_test.cpp
@@ -98,3 +98,37 @@ TEST(StreamReference, RowVectorStreamReference) {
   ASSERT_EQ(1, d.rows());
   ASSERT_EQ(2, d.cols());
 }
+
+TEST(StreamReference, StreamMappingReference) {
+  lin::Matrix3x3f const A = {
+    0.0f, 1.0f, 2.0f,
+    3.0f, 4.0f, 5.0f,
+    6.0f, 7.0f, 8.0f
+  };
+  lin::Vector3f const a = {
+    0.0f,
+    4.0f,
+    8.0f
+  };
+
+  auto const b = lin::diag(A);
+  static_assert(lin::internal::have_same_traits<std::remove_const_t<decltype(b)>, lin::Vector3f>::value, "");
+  ASSERT_FLOAT_EQ(0.0f, lin::fro(a - b));
+  ASSERT_EQ(3, b.rows());
+  ASSERT_EQ(1, b.cols());
+
+  lin::Matrixf<0, 0, 5, 5> const B(2, 2, {
+    0.0f, 1.0f,
+    2.0f, 3.0f
+  });
+  lin::Vectorf<0, 5> const c(2, {
+    0.0f,
+    3.0f
+  });
+
+  auto const d = lin::diag(B);
+  static_assert(lin::internal::have_same_traits<std::remove_const_t<decltype(d)>, lin::Vectorf<0, 5>>::value, "");
+  ASSERT_FLOAT_EQ(0.0f, lin::fro(c - d));
+  ASSERT_EQ(2, d.rows());
+  ASSERT_EQ(1, d.cols());
+}


### PR DESCRIPTION
Will be rebased once #22 is merged.

### Summary of Changes

* Refactor `lin::ref_col` and `lin::ref_row` to `lin::col` and `lin::row` respectively.
* Added the `lin::diag` function to the generators module to allow square matrices to be created by sparsely specifying the elements along the diagonal.
* Added the `lin::diag` function to the references module to allow the diagonal elements of a square matrix to be treated as a column vector. Taking the trace of a matrix, as an example, can now be done with:

        #include <lin/core.hpp>
        #include <lin/references.hpp>

        lin::sum(lin::diag(...));
