### PR TITLE
Mapping Transpose Operation

### DIFF
--- a/include/lin/core/operations/mapping_transpose.hpp
+++ b/include/lin/core/operations/mapping_transpose.hpp
@@ -66,29 +66,25 @@ class MappingTranspose : public Mapping<MappingTranspose<C>> {
     return c.rows();
   }
 
-  /** @brief Lazily evaluates the requested tensor element.
+  /** @brief Read write access to the requested tensor element.
    * 
    *  @param i Row index.
    *  @param j Column index.
    * 
-   *  @return Resulting value of the tensor element.
-   * 
-   *  @sa internal::TensorStream::eval
+   *  @return Reference to the tensor element.
    */
   constexpr typename Traits::elem_t &operator()(size_t i, size_t j) {
     return c(j, i);
   }
 
-  /** @brief Lazily evaluates the requested tensor element.
+  /** @brief Read write access to the requested tensor element.
    * 
    *  @param i Index.
    * 
-   *  @return Resulting value of the tensor element.
+   *  @return Reference to the tensor element.
    * 
    *  Element access proceeds as if all the elements of the tensor stream were
    *  flattened into an array in row major order.
-   * 
-   *  @sa internal::TensorStream::eval
    */
   constexpr typename Traits::elem_t &operator()(size_t i) {
     return (*this)(i / cols(), i % cols());

--- a/include/lin/core/operations/mapping_transpose.hpp
+++ b/include/lin/core/operations/mapping_transpose.hpp
@@ -1,0 +1,111 @@
+// vim: set tabstop=2:softtabstop=2:shiftwidth=2:expandtab
+
+/** @file lin/core/operations/mapping_transpose.hpp
+ *  @author Kyle Krol
+ */
+
+#ifndef LIN_CORE_OPERATIONS_MAPPING_TRANSPOSE_HPP_
+#define LIN_CORE_OPERATIONS_MAPPING_TRANSPOSE_HPP_
+
+namespace lin {
+namespace internal {
+
+/** @brief Proxy to a lazily evalutated transpose operation.
+ * 
+ *  @tparam Cs %Tensor type.
+ * 
+ *  Details to come...
+ * 
+ *  @ingroup COREOPERATIONS
+ */
+template <class C>
+class MappingTranspose : public Mapping<MappingTranspose<C>> {
+ private:
+  /** @brief Mapping reference.
+   */
+  Mapping<C> &c;
+
+ public:
+  /** @brief Traits information for this type.
+   * 
+   *  @sa internal::traits
+   */
+  typedef traits<MappingTranspose<C>> Traits;
+
+ protected:
+  using Mapping<MappingTranspose<C>>::derived;
+
+ public:
+  using Mapping<MappingTranspose<C>>::size;
+  using Mapping<MappingTranspose<C>>::eval;
+  using Mapping<MappingTranspose<C>>::operator();
+  using Mapping<MappingTranspose<C>>::operator=;
+
+  constexpr MappingTranspose() = delete;
+  constexpr MappingTranspose(MappingTranspose<C> const &) = default;
+  constexpr MappingTranspose(MappingTranspose<C> &&) = default;
+  constexpr MappingTranspose<C> &operator=(MappingTranspose<C> const &) = default;
+  constexpr MappingTranspose<C> &operator=(MappingTranspose<C> &&) = default;
+
+  /** @brief Constructs a proxy to a tensor transpose operation.
+   * 
+   *  @param c %Tensor mapping.
+   */
+  constexpr MappingTranspose(Mapping<C> &c)
+  : c(c) { }
+
+  /** @return Number of rows in the tensor.
+   */
+  constexpr size_t rows() const {
+    return c.cols();
+  }
+
+  /** @return Number of columns in the tensor.
+   */
+  constexpr size_t cols() const {
+    return c.rows();
+  }
+
+  /** @brief Lazily evaluates the requested tensor element.
+   * 
+   *  @param i Row index.
+   *  @param j Column index.
+   * 
+   *  @return Resulting value of the tensor element.
+   * 
+   *  @sa internal::TensorStream::eval
+   */
+  constexpr typename Traits::elem_t &operator()(size_t i, size_t j) {
+    return c(j, i);
+  }
+
+  /** @brief Lazily evaluates the requested tensor element.
+   * 
+   *  @param i Index.
+   * 
+   *  @return Resulting value of the tensor element.
+   * 
+   *  Element access proceeds as if all the elements of the tensor stream were
+   *  flattened into an array in row major order.
+   * 
+   *  @sa internal::TensorStream::eval
+   */
+  constexpr typename Traits::elem_t &operator()(size_t i) {
+    return (*this)(i / cols(), i % cols());
+  }
+};
+
+template <class C>
+struct _elem<MappingTranspose<C>> : _elem<C> { };
+
+template <class C>
+struct _dims<MappingTranspose<C>> {
+  static constexpr size_t rows = _dims<C>::cols;
+  static constexpr size_t cols = _dims<C>::rows;
+  static constexpr size_t max_rows = _dims<C>::max_cols;
+  static constexpr size_t max_cols = _dims<C>::max_rows;
+};
+}  // namespace internal
+}  // namespace lin
+
+#endif

--- a/include/lin/core/operations/tensor_operations.hpp
+++ b/include/lin/core/operations/tensor_operations.hpp
@@ -11,6 +11,7 @@
 #include "../traits.hpp"
 #include "../types.hpp"
 #include "functors.hpp"
+#include "mapping_transpose.hpp"
 #include "stream_element_wise_operator.hpp"
 #include "stream_transpose.hpp"
 
@@ -314,6 +315,12 @@ constexpr auto sum(internal::Stream<C> const &c) {
   typename C::Traits::elem_t x = c(0);
   for (lin::size_t i = 1; i < c.size(); i++) x += c(i);
   return x;
+}
+
+template <class C, std::enable_if_t<
+    internal::matches_tensor<C>::value, size_t> = 0>
+constexpr auto transpose(internal::Mapping<C> &c) {
+  return internal::MappingTranspose<C>(c);
 }
 
 template <class C, std::enable_if_t<

--- a/test/core/operations_tensor_operations_test.cpp
+++ b/test/core/operations_tensor_operations_test.cpp
@@ -178,13 +178,19 @@ TEST(CoreOperationsTensorOperations, Sum) {
   ASSERT_FLOAT_EQ(2.0f, lin::sum(A));
 }
 
-TEST(CoreOperationsTensorOperations, Transpose) {
+TEST(CoreOperationsTensorOperations, MappingTranspose) {
   lin::Matrix2x2f A({0.0f, 1.0f, 2.0f, 3.0f});
-  auto const transpose_A = lin::transpose(A);
+  auto transpose_A = lin::transpose(A);
   ASSERT_FLOAT_EQ(0.0f, transpose_A(0, 0));
   ASSERT_FLOAT_EQ(2.0f, transpose_A(0, 1));
   ASSERT_FLOAT_EQ(1.0f, transpose_A(1, 0));
   ASSERT_FLOAT_EQ(3.0f, transpose_A(1, 1));
+
+  transpose_A = { 1.0f, 2.0f, 3.0f, 4.0f };
+  ASSERT_FLOAT_EQ(1.0f, A(0, 0));
+  ASSERT_FLOAT_EQ(3.0f, A(0, 1));
+  ASSERT_FLOAT_EQ(2.0f, A(1, 0));
+  ASSERT_FLOAT_EQ(4.0f, A(1, 1));
 
   lin::Matrixf<0, 0, 4, 4> B(3, 2);
   auto const transpose_B = lin::transpose(B);
@@ -193,6 +199,27 @@ TEST(CoreOperationsTensorOperations, Transpose) {
   ASSERT_EQ(6, transpose_B.size());
 
   lin::Matrix2x4f C;
+  auto const transpose_C = lin::transpose(C);
+  ASSERT_EQ(4, transpose_C.rows());
+  ASSERT_EQ(2, transpose_C.cols());
+  ASSERT_EQ(8, transpose_C.size());
+}
+
+TEST(CoreOperationsTensorOperations, StreamTranspose) {
+  lin::Matrix2x2f const A({0.0f, 1.0f, 2.0f, 3.0f});
+  auto const transpose_A = lin::transpose(A);
+  ASSERT_FLOAT_EQ(0.0f, transpose_A(0, 0));
+  ASSERT_FLOAT_EQ(2.0f, transpose_A(0, 1));
+  ASSERT_FLOAT_EQ(1.0f, transpose_A(1, 0));
+  ASSERT_FLOAT_EQ(3.0f, transpose_A(1, 1));
+
+  lin::Matrixf<0, 0, 4, 4> const B(3, 2);
+  auto const transpose_B = lin::transpose(B);
+  ASSERT_EQ(2, transpose_B.rows());
+  ASSERT_EQ(3, transpose_B.cols());
+  ASSERT_EQ(6, transpose_B.size());
+
+  lin::Matrix2x4f const C;
   auto const transpose_C = lin::transpose(C);
   ASSERT_EQ(4, transpose_C.rows());
   ASSERT_EQ(2, transpose_C.cols());


### PR DESCRIPTION
Added the mapping transpose operation.

Previously, there was only a transpose operation taking in a constant stream. This mean you couldn't assign to the result of a transpose operation even if it makes total sense for that to happen. Now you can do something like this:

    lin::Matrix2x2d A;
    lin::transpose(A) = { 0.0, 1.0, 2.0, 3.0 };

which has the exact same result as doing:

    lin::Matrix2x2d A;
    A = { 0.0, 2.0, 1.0, 3.0 };